### PR TITLE
Fix NIMH warning logic and add tests

### DIFF
--- a/ingest/crawlers/nimh-severe-weather/parser.test.ts
+++ b/ingest/crawlers/nimh-severe-weather/parser.test.ts
@@ -183,4 +183,82 @@ describe("hasActiveWarnings", () => {
 
     expect(hasActiveWarnings(data)).toBe(false);
   });
+
+  it("returns false when recommendation is 'Няма опасност'", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "Няма опасност",
+      sofiaWarnings: [],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(false);
+  });
+
+  it("returns false when recommendation contains 'няма опасност' (case insensitive)", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "За София няма опасност от опасно време.",
+      sofiaWarnings: [],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(false);
+  });
+
+  it("returns false when recommendation is 'без опасност'", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "Без опасност",
+      sofiaWarnings: [],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(false);
+  });
+
+  it("returns false when recommendation contains 'не се очаква опасност'", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "Не се очаква опасност от силни ветрове.",
+      sofiaWarnings: [],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(false);
+  });
+
+  it("returns true when there are warnings even if recommendation says no danger", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "Няма опасност",
+      sofiaWarnings: [
+        {
+          type: "wind" as const,
+          level: "yellow" as const,
+          notes: ["Силен вятър"],
+        },
+      ],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(true);
+  });
+
+  it("returns false when only green warnings exist with no-danger recommendation", () => {
+    const data = {
+      forecastDate: "2026-02-01",
+      issuedAt: "2026-01-31T11:02:45",
+      recommendation: "Няма опасност",
+      sofiaWarnings: [
+        {
+          type: "wind" as const,
+          level: "green" as const,
+          notes: [],
+        },
+      ],
+    };
+
+    expect(hasActiveWarnings(data)).toBe(false);
+  });
 });

--- a/ingest/crawlers/nimh-severe-weather/parser.ts
+++ b/ingest/crawlers/nimh-severe-weather/parser.ts
@@ -184,14 +184,31 @@ function parseSofiaRow(html: string): WarningCell[] {
 }
 
 /**
+ * Phrases that indicate no danger (case-insensitive)
+ */
+const NO_DANGER_PHRASES = [
+  "няма опасност",
+  "без опасност",
+  "не се очаква опасност",
+];
+
+/**
  * Check if the parsed data contains any actual warnings
  */
 export function hasActiveWarnings(data: WeatherPageData): boolean {
-  // Has recommendation text
-  if (data.recommendation.length > 0) {
+  // Has any non-green warnings (green is always ignored)
+  if (data.sofiaWarnings.some((w) => w.level !== "green")) {
     return true;
   }
 
-  // Has any non-green warnings (green is always ignored)
-  return data.sofiaWarnings.some((w) => w.level !== "green");
+  // Check recommendation text - only counts if it's not a "no danger" message
+  if (data.recommendation.length > 0) {
+    const lowerRec = data.recommendation.toLowerCase();
+    const isNoDanger = NO_DANGER_PHRASES.some((phrase) =>
+      lowerRec.includes(phrase),
+    );
+    return !isNoDanger;
+  }
+
+  return false;
 }

--- a/ingest/crawlers/nimh-severe-weather/parser.ts
+++ b/ingest/crawlers/nimh-severe-weather/parser.ts
@@ -184,7 +184,8 @@ function parseSofiaRow(html: string): WarningCell[] {
 }
 
 /**
- * Phrases that indicate no danger (case-insensitive)
+ * Phrases that indicate no danger
+ * (keep lowercased for case-insensitive comparisons)
  */
 const NO_DANGER_PHRASES = [
   "няма опасност",


### PR DESCRIPTION
Update the logic in the `hasActiveWarnings` function to correctly handle recommendations indicating no danger and ensure that only relevant warnings are considered. Add tests to validate the behavior of the function under various scenarios.

refs #21