### PR TITLE
Emulators can run without Docker; local seed no longer fails silently

### DIFF
--- a/docs/setup/quick-start-emulators.md
+++ b/docs/setup/quick-start-emulators.md
@@ -62,7 +62,7 @@ cd web
 npm run dev
 ```
 
-If using emulators, make sure to add your Google Maps API key to the `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` variable in `web/.env.local`.
+Make sure to add your Google Maps API key to the `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` variable in `web/.env.local`.
 
 **App:** http://localhost:3000
 

--- a/docs/setup/quick-start-emulators.md
+++ b/docs/setup/quick-start-emulators.md
@@ -26,11 +26,20 @@ cd web && npm install && cd ..
 
 ### 3. Start Emulators
 
+#### 3.1. via Docker
+
 ```bash
 docker-compose up firebase-emulators
 ```
 
 Wait for: `✔  All emulators ready! It is now safe to connect your app.`
+
+#### 3.2. without using Docker
+
+```bash
+cd ingest
+npm run emulators
+```
 
 **Emulator UI:** http://localhost:4000
 
@@ -51,6 +60,8 @@ Stop emulators (Ctrl+C), then restart. Data persists across restarts.
 cd web
 npm run dev
 ```
+
+If using emulators, make sure you've added your Google Maps API key to `web/.env.local`
 
 **App:** http://localhost:3000
 

--- a/docs/setup/quick-start-emulators.md
+++ b/docs/setup/quick-start-emulators.md
@@ -41,6 +41,7 @@ cd ingest
 npm run emulators
 ```
 
+Wait for: `✔  All emulators ready! It is now safe to connect your app.`
 **Emulator UI:** http://localhost:4000
 
 ### 4. Seed Test Data (First Time)

--- a/docs/setup/quick-start-emulators.md
+++ b/docs/setup/quick-start-emulators.md
@@ -62,7 +62,7 @@ cd web
 npm run dev
 ```
 
-If using emulators, make sure you've added your Google Maps API key to `web/.env.local`
+If using emulators, make sure to add your Google Maps API key to the `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` variable in `web/.env.local`.
 
 **App:** http://localhost:3000
 

--- a/ingest/.firebaserc
+++ b/ingest/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "oborishte-map"
+    "default": "demo-project"
   }
 }

--- a/ingest/.gitignore
+++ b/ingest/.gitignore
@@ -6,6 +6,7 @@ docker-shared/
 # Firebase Emulator data - allow base directory, ignore exports
 emulator-data/**/*_export
 emulator-data/**/*.log
+*export-metadata.json
 
 # Mock fixtures - allow base directory, ignore custom fixtures
 __mocks__/fixtures/**/*-custom.json

--- a/ingest/.gitignore
+++ b/ingest/.gitignore
@@ -6,7 +6,7 @@ docker-shared/
 # Firebase Emulator data - allow base directory, ignore exports
 emulator-data/**/*_export
 emulator-data/**/*.log
-*export-metadata.json
+emulator-data/**/firebase-export-metadata.json
 
 # Mock fixtures - allow base directory, ignore custom fixtures
 __mocks__/fixtures/**/*-custom.json

--- a/web/.env.example.emulator
+++ b/web/.env.example.emulator
@@ -23,8 +23,7 @@ NEXT_PUBLIC_FIREBASE_DATABASE_ID=(default)
 # Base URL for local development
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
-# Google Maps API Key (optional for emulator mode)
-# Leave empty to skip map display, or use your key
+# Google Maps API Key
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 
 # Message Relevance Period (in days)


### PR DESCRIPTION
- updated documentation with substep on how to run emulators without Docker
- updated default project in `ingest/.firebaserc`, so that it matches the one in `ingest/.env.example.emulator`, thus `npm run emulator:seed` no longer fails silently
- Google Maps API key not optional when running locally with emulators as no messages are fetched before map is loaded