### PR TITLE
feat: implement automatic map centering on user location at load

### DIFF
--- a/web/components/HomeContent.tsx
+++ b/web/components/HomeContent.tsx
@@ -248,6 +248,7 @@ export default function HomeContent() {
           onCancelTargetMode={handleCancelTargetMode}
           onStartAddInterest={handleStartAddInterest}
           onGeolocationPromptChange={setGeolocationPrompt}
+          shouldTrackLocation={true}
         />
         {isLoading && (
           <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-white px-4 py-2 rounded-lg shadow-md z-20">

--- a/web/components/MapComponent.tsx
+++ b/web/components/MapComponent.tsx
@@ -266,7 +266,24 @@ export default function MapComponent({
       setUserLocation(null);
     };
   }, [shouldTrackLocation]);
-
+useEffect(() => {
+  if (shouldTrackLocation && navigator.geolocation) {
+ 
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        setUserLocation({ lat: latitude, lng: longitude });
+        if (mapRef.current) {
+          centerMap(latitude, longitude, 15);
+        }
+      },
+      (error) => {
+        console.error("Erro na geolocalização automática:", error);
+      },
+      { enableHighAccuracy: false, timeout: 5000, maximumAge: Infinity }
+    );
+  }
+}, [shouldTrackLocation, centerMap]);
   return (
     <div className="absolute inset-0">
       {process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ? (

--- a/web/components/MapContainer.tsx
+++ b/web/components/MapContainer.tsx
@@ -52,6 +52,7 @@ interface MapContainerProps {
       onDecline: () => void;
     } | null,
   ) => void;
+  readonly shouldTrackLocation?: boolean;
 }
 
 export default function MapContainer({
@@ -69,6 +70,7 @@ export default function MapContainer({
   onCancelTargetMode,
   onStartAddInterest,
   onGeolocationPromptChange,
+  shouldTrackLocation: initialShouldTrack = false,
 }: MapContainerProps) {
   const [centerMap, setCenterMap] = useState<
     | ((
@@ -137,7 +139,7 @@ export default function MapContainer({
     hasSubscriptions,
   });
 
-  const [isTrackingLocation, setIsTrackingLocation] = useState(false);
+  const [isTrackingLocation, setIsTrackingLocation] = useState(initialShouldTrack);
 
   const { showPrompt, onAccept, onDecline, requestGeolocation, isLocating } =
     useGeolocationPrompt();

--- a/web/components/MapContainer.tsx
+++ b/web/components/MapContainer.tsx
@@ -140,6 +140,9 @@ export default function MapContainer({
   });
 
   const [isTrackingLocation, setIsTrackingLocation] = useState(initialShouldTrack);
+  useEffect(() => {
+    setIsTrackingLocation(initialShouldTrack);
+  }, [initialShouldTrack]);
 
   const { showPrompt, onAccept, onDecline, requestGeolocation, isLocating } =
     useGeolocationPrompt();


### PR DESCRIPTION
<img width="1907" height="958" alt="Screenshot 2026-02-10 121214" src="https://github.com/user-attachments/assets/b9af2230-e249-4c19-a186-19227b9c2ca1" />

I have implemented automatic map centering on the user's location upon initial load to satisfy Issue #111. To achieve this, I synchronized the shouldTrackLocation flag from HomeContent down to MapComponent, where I utilized navigator.geolocation.getCurrentPosition within a useEffect hook. This triggers the camera movement and zoom adjustment as soon as both the map instance and coordinates are ready. This change ensures the user is proactively localized when opening the application, removing the need for manual interaction with the geolocation button for the initial positioning.