### PR TITLE
notification filters by category and source

### DIFF
--- a/db/src/collections/index.ts
+++ b/db/src/collections/index.ts
@@ -11,3 +11,7 @@ export {
   NOTIFICATION_SUBSCRIPTIONS_COLLECTION,
 } from "./notification-subscriptions";
 export { GtfsStopsRepository, GTFS_STOPS_COLLECTION } from "./gtfs-stops";
+export {
+  UserPreferencesRepository,
+  USER_PREFERENCES_COLLECTION,
+} from "./user-preferences";

--- a/db/src/collections/user-preferences.ts
+++ b/db/src/collections/user-preferences.ts
@@ -1,0 +1,73 @@
+/**
+ * User preferences collection repository.
+ *
+ * Stores per-user settings such as notification filter preferences.
+ * Each user has at most one document in this collection.
+ */
+
+import type { DbClient, FindManyOptions } from "../types";
+
+/** Collection name constant */
+export const USER_PREFERENCES_COLLECTION = "userPreferences";
+
+export class UserPreferencesRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async findById(id: string): Promise<Record<string, unknown> | null> {
+    return this.db.findOne(USER_PREFERENCES_COLLECTION, id);
+  }
+
+  async findMany(
+    options?: FindManyOptions,
+  ): Promise<Record<string, unknown>[]> {
+    return this.db.findMany(USER_PREFERENCES_COLLECTION, options);
+  }
+
+  async insertOne(data: Record<string, unknown>): Promise<string> {
+    return this.db.insertOne(USER_PREFERENCES_COLLECTION, data);
+  }
+
+  async updateOne(id: string, data: Record<string, unknown>): Promise<void> {
+    return this.db.updateOne(USER_PREFERENCES_COLLECTION, id, data);
+  }
+
+  async deleteOne(id: string): Promise<void> {
+    return this.db.deleteOne(USER_PREFERENCES_COLLECTION, id);
+  }
+
+  /** Find preferences for a user (returns first match or null) */
+  async findByUserId(userId: string): Promise<Record<string, unknown> | null> {
+    const results = await this.db.findMany(USER_PREFERENCES_COLLECTION, {
+      where: [{ field: "userId", op: "==", value: userId }],
+      limit: 1,
+    });
+    return results[0] ?? null;
+  }
+
+  /**
+   * Create or update preferences for a user.
+   * If a document already exists for the userId, it is updated.
+   * Otherwise a new document is created.
+   * Returns the document ID.
+   */
+  async upsertByUserId(
+    userId: string,
+    data: Record<string, unknown>,
+  ): Promise<string> {
+    const existing = await this.findByUserId(userId);
+    const now = new Date();
+
+    if (existing) {
+      const docId = existing._id as string;
+      await this.updateOne(docId, { ...data, updatedAt: now });
+      return docId;
+    }
+
+    return this.insertOne({
+      ...data,
+      userId,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}

--- a/db/src/collections/user-preferences.ts
+++ b/db/src/collections/user-preferences.ts
@@ -35,13 +35,36 @@ export class UserPreferencesRepository {
     return this.db.deleteOne(USER_PREFERENCES_COLLECTION, id);
   }
 
-  /** Find preferences for a user (returns first match or null) */
+  /**
+   * Find preferences for a user (returns first match or null) */
   async findByUserId(userId: string): Promise<Record<string, unknown> | null> {
     const results = await this.db.findMany(USER_PREFERENCES_COLLECTION, {
       where: [{ field: "userId", op: "==", value: userId }],
       limit: 1,
     });
     return results[0] ?? null;
+  }
+
+  /**
+   * Find preferences for multiple users in a single batched query.
+   * Batches in groups of 30 to avoid 'in' operator limits.
+   */
+  async findByUserIds(
+    userIds: string[],
+  ): Promise<Record<string, unknown>[]> {
+    if (userIds.length === 0) return [];
+    const BATCH_SIZE = 30;
+    const results: Record<string, unknown>[] = [];
+
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batch = userIds.slice(i, i + BATCH_SIZE);
+      const docs = await this.db.findMany(USER_PREFERENCES_COLLECTION, {
+        where: [{ field: "userId", op: "in", value: batch }],
+      });
+      results.push(...docs);
+    }
+
+    return results;
   }
 
   /**

--- a/db/src/collections/user-preferences.ts
+++ b/db/src/collections/user-preferences.ts
@@ -2,7 +2,7 @@
  * User preferences collection repository.
  *
  * Stores per-user settings such as notification filter preferences.
- * Each user has at most one document in this collection.
+ * The document ID equals the user's `userId` — enforcing one document per user at the DB level.
  */
 
 import type { DbClient, FindManyOptions } from "../types";
@@ -23,10 +23,6 @@ export class UserPreferencesRepository {
     return this.db.findMany(USER_PREFERENCES_COLLECTION, options);
   }
 
-  async insertOne(data: Record<string, unknown>): Promise<string> {
-    return this.db.insertOne(USER_PREFERENCES_COLLECTION, data);
-  }
-
   async updateOne(id: string, data: Record<string, unknown>): Promise<void> {
     return this.db.updateOne(USER_PREFERENCES_COLLECTION, id, data);
   }
@@ -36,61 +32,60 @@ export class UserPreferencesRepository {
   }
 
   /**
-   * Find preferences for a user (returns first match or null) */
+   * Find preferences for a user.
+   * Since userId IS the document ID, this is a direct O(1) lookup.
+   */
   async findByUserId(userId: string): Promise<Record<string, unknown> | null> {
-    const results = await this.db.findMany(USER_PREFERENCES_COLLECTION, {
-      where: [{ field: "userId", op: "==", value: userId }],
-      limit: 1,
-    });
-    return results[0] ?? null;
+    return this.db.findOne(USER_PREFERENCES_COLLECTION, userId);
   }
 
   /**
-   * Find preferences for multiple users in a single batched query.
-   * Batches in groups of 30 to avoid 'in' operator limits.
+   * Find preferences for multiple users.
+   * Uses parallel findOne lookups since userId IS the document ID.
    */
   async findByUserIds(
     userIds: string[],
   ): Promise<Record<string, unknown>[]> {
     if (userIds.length === 0) return [];
-    const BATCH_SIZE = 30;
-    const results: Record<string, unknown>[] = [];
-
-    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
-      const batch = userIds.slice(i, i + BATCH_SIZE);
-      const docs = await this.db.findMany(USER_PREFERENCES_COLLECTION, {
-        where: [{ field: "userId", op: "in", value: batch }],
-      });
-      results.push(...docs);
-    }
-
-    return results;
+    const results = await Promise.all(
+      userIds.map((id) => this.db.findOne(USER_PREFERENCES_COLLECTION, id)),
+    );
+    return results.filter((r): r is Record<string, unknown> => r !== null);
   }
 
   /**
-   * Create or update preferences for a user.
-   * If a document already exists for the userId, it is updated.
-   * Otherwise a new document is created.
-   * Returns the document ID.
+   * Atomically create or update preferences for a user.
+   * Uses userId as the document ID for uniqueness at the DB level.
+   * Tries createOne first; on conflict (already exists) falls back to updateOne.
+   * Returns the document ID (which equals userId).
    */
   async upsertByUserId(
     userId: string,
     data: Record<string, unknown>,
   ): Promise<string> {
-    const existing = await this.findByUserId(userId);
     const now = new Date();
-
-    if (existing) {
-      const docId = existing._id as string;
-      await this.updateOne(docId, { ...data, updatedAt: now });
-      return docId;
+    try {
+      return await this.db.createOne(
+        USER_PREFERENCES_COLLECTION,
+        { ...data, createdAt: now, updatedAt: now },
+        userId,
+      );
+    } catch (error) {
+      // If document already exists, update instead; otherwise rethrow
+      const isAlreadyExists =
+        error instanceof Error &&
+        (error.message.includes("ALREADY_EXISTS") ||
+          error.message.includes("already exists") ||
+          (error as { code?: unknown }).code === 6 ||
+          (error as { code?: unknown }).code === "already-exists");
+      if (!isAlreadyExists) {
+        throw error;
+      }
+      await this.db.updateOne(USER_PREFERENCES_COLLECTION, userId, {
+        ...data,
+        updatedAt: now,
+      });
+      return userId;
     }
-
-    return this.insertOne({
-      ...data,
-      userId,
-      createdAt: now,
-      updatedAt: now,
-    });
   }
 }

--- a/db/src/index.test.ts
+++ b/db/src/index.test.ts
@@ -80,6 +80,7 @@ describe("createDbFromConfig", () => {
     expect(db.notificationMatches).toBeDefined();
     expect(db.notificationSubscriptions).toBeDefined();
     expect(db.gtfsStops).toBeDefined();
+    expect(db.userPreferences).toBeDefined();
     expect(typeof db.close).toBe("function");
   });
 

--- a/db/src/index.ts
+++ b/db/src/index.ts
@@ -20,6 +20,7 @@ import { NotificationMatchesRepository } from "./collections/notification-matche
 import { NotificationSubscriptionsRepository } from "./collections/notification-subscriptions";
 import { GtfsStopsRepository } from "./collections/gtfs-stops";
 import { ApiClientsRepository } from "./collections/api-clients";
+import { UserPreferencesRepository } from "./collections/user-preferences";
 
 /** High-level database interface with typed collection repositories */
 export interface OboDb {
@@ -39,6 +40,8 @@ export interface OboDb {
   gtfsStops: GtfsStopsRepository;
   /** Registered external API clients */
   apiClients: ApiClientsRepository;
+  /** User preferences (notification filters, etc.) */
+  userPreferences: UserPreferencesRepository;
   /** Close all database connections */
   close(): Promise<void>;
 }
@@ -67,6 +70,7 @@ function buildRepositories(client: DbClient): OboDb {
     notificationSubscriptions: new NotificationSubscriptionsRepository(client),
     gtfsStops: new GtfsStopsRepository(client),
     apiClients: new ApiClientsRepository(client),
+    userPreferences: new UserPreferencesRepository(client),
     close: () => client.close(),
   };
 }

--- a/e2e/notification-filters.feature
+++ b/e2e/notification-filters.feature
@@ -1,0 +1,187 @@
+Feature: Notification Filters
+  As a user of oboapp
+  I want to filter which notifications I receive by category and source
+  So that I only get notified about disruptions I care about
+
+  Background:
+    Given I am logged in
+    And I have at least one interest circle on the map
+    And I have an active push notification subscription
+
+  # ─── Navigation ───────────────────────────────────────────────────────
+
+  Scenario: Open Notification Filters from the notifications dropdown
+    When I click the notification bell icon
+    And I click the "Филтри" link in the notification dropdown header
+    Then I am navigated to "/settings/notification-filters"
+    And I see a "Категории" section with all 17 categories and an "Некатегоризирани" option
+    And I see a "Източници" section with all sources for my locality
+
+  Scenario: Open Notification Filters from the Settings page
+    When I navigate to "/settings"
+    And I click the "Филтри за известия" link in the Notifications section
+    Then I am navigated to "/settings/notification-filters"
+
+  # ─── Default State (No Filters) ──────────────────────────────────────
+
+  Scenario: Default state shows no active filters
+    When I navigate to "/settings/notification-filters"
+    Then no categories are selected
+    And no sources are selected
+    And I see a note that "Промените ще се приложат само за бъдещи известия"
+
+  Scenario: No filters means all notifications are delivered
+    Given I have no notification filter preferences saved
+    When a new message is ingested with category "water" from source "sofiyska-voda"
+    And the message geographically intersects my interest circle
+    Then a notification match is created for me
+    And I receive a push notification
+
+  # ─── Category Filtering ──────────────────────────────────────────────
+
+  Scenario: Select a single category filter
+    When I navigate to "/settings/notification-filters"
+    And I select the "Вода" category
+    And I click "Запази"
+    Then my notification preferences are saved with categories ["water"]
+    And I am navigated back to the settings page
+
+  Scenario: Only matching category notifications are delivered
+    Given I have notification category filter set to ["water"]
+    When a message with category "water" intersects my interest circle
+    Then a notification match is created for me
+    When a message with category "electricity" intersects my interest circle
+    Then no notification match is created for me
+
+  Scenario: Message with multiple categories matches if any category is selected
+    Given I have notification category filter set to ["water"]
+    When a message with categories ["water", "construction-and-repairs"] intersects my interest circle
+    Then a notification match is created for me
+
+  Scenario: Filter for uncategorized messages
+    Given I have notification category filter set to ["uncategorized"]
+    When a message with no categories intersects my interest circle
+    Then a notification match is created for me
+    When a message with category "heating" intersects my interest circle
+    Then no notification match is created for me
+
+  Scenario: Select all categories
+    When I navigate to "/settings/notification-filters"
+    And I click "Избери всички" in the Категории section
+    Then all 17 categories and "Некатегоризирани" are selected
+    When I click "Запази"
+    Then my preferences are saved with all categories selected
+
+  Scenario: Deselect all categories
+    Given I have notification category filter set to ["water", "electricity"]
+    When I navigate to "/settings/notification-filters"
+    And I click "Изчисти всички" in the Категории section
+    Then no categories are selected
+    When I click "Запази"
+    Then my notification preferences are saved with categories []
+    And all future messages pass the category filter (no restriction)
+
+  # ─── Source Filtering ────────────────────────────────────────────────
+
+  Scenario: Select a single source filter
+    When I navigate to "/settings/notification-filters"
+    And I select the "Софийска вода" source
+    And I click "Запази"
+    Then my notification preferences are saved with sources ["sofiyska-voda"]
+
+  Scenario: Only matching source notifications are delivered
+    Given I have notification source filter set to ["sofiyska-voda"]
+    When a message from source "sofiyska-voda" intersects my interest circle
+    Then a notification match is created for me
+    When a message from source "toplo-bg" intersects my interest circle
+    Then no notification match is created for me
+
+  Scenario: Select all sources
+    When I navigate to "/settings/notification-filters"
+    And I click "Избери всички" in the Източници section
+    Then all sources for my locality are selected
+
+  Scenario: Deselect all sources
+    Given I have notification source filter set to ["sofiyska-voda", "toplo-bg"]
+    When I navigate to "/settings/notification-filters"
+    And I click "Изчисти всички" in the Източници section
+    And I click "Запази"
+    Then my notification preferences are saved with sources []
+    And all future messages pass the source filter (no restriction)
+
+  # ─── Combined Filters ───────────────────────────────────────────────
+
+  Scenario: Both category and source filters must match
+    Given I have notification category filter set to ["water"]
+    And I have notification source filter set to ["sofiyska-voda"]
+    When a "water" message from "sofiyska-voda" intersects my interest circle
+    Then a notification match is created for me
+    When a "water" message from "toplo-bg" intersects my interest circle
+    Then no notification match is created for me
+    When an "electricity" message from "sofiyska-voda" intersects my interest circle
+    Then no notification match is created for me
+
+  # ─── Save / Cancel / Clear ──────────────────────────────────────────
+
+  Scenario: Cancel discards unsaved changes
+    Given I have notification category filter set to ["water"]
+    When I navigate to "/settings/notification-filters"
+    And I additionally select the "Електричество" category
+    And I click "Отказ"
+    Then I am navigated away from the filters page
+    When I navigate back to "/settings/notification-filters"
+    Then only "Вода" is selected in categories
+
+  Scenario: Clear all filters removes all active filters
+    Given I have notification category filter set to ["water", "electricity"]
+    And I have notification source filter set to ["sofiyska-voda"]
+    When I navigate to "/settings/notification-filters"
+    And I click "Изчисти всички филтри"
+    And I click "Запази"
+    Then my notification preferences are saved with categories [] and sources []
+    And all future messages are delivered without filtering
+
+  # ─── Persistence & Cross-Device ─────────────────────────────────────
+
+  Scenario: Filter preferences persist across page reloads
+    Given I have saved notification filters with categories ["water"] and sources ["sofiyska-voda"]
+    When I reload the page
+    And I navigate to "/settings/notification-filters"
+    Then "Вода" is selected in categories
+    And "Софийска вода" is selected in sources
+
+  Scenario: Filter preferences apply across all devices
+    Given I have saved notification filters with categories ["water"]
+    When I log in on a different device
+    And a "water" message intersects my interest circle
+    Then a notification match is created for me on both devices
+    When an "electricity" message intersects my interest circle
+    Then no notification match is created for me on either device
+
+  # ─── Non-Retroactive Behavior ───────────────────────────────────────
+
+  Scenario: Existing notification matches are not affected by new filters
+    Given I previously received a notification match for an "electricity" message
+    When I set notification category filter to ["water"]
+    Then the existing "electricity" notification match still appears in my notification history
+    And it is not deleted or hidden
+
+  # ─── Edge Cases ─────────────────────────────────────────────────────
+
+  Scenario: City-wide messages respect filters
+    Given I have notification category filter set to ["weather"]
+    When a city-wide message with category "weather" is ingested
+    Then a notification match is created for me
+    When a city-wide message with category "water" is ingested
+    Then no notification match is created for me
+
+  Scenario: User with no interest circles receives no notifications regardless of filters
+    Given I have no interest circles on the map
+    And I have notification category filter set to ["water"]
+    When a "water" message is ingested
+    Then no notification match is created for me
+
+  Scenario: Unauthenticated user cannot access filters page
+    Given I am not logged in
+    When I navigate to "/settings/notification-filters"
+    Then I am redirected to the home page

--- a/e2e/notification-filters.feature
+++ b/e2e/notification-filters.feature
@@ -69,6 +69,7 @@ Feature: Notification Filters
     When I navigate to "/settings/notification-filters"
     And I click "Избери всички" in the Категории section
     Then all 17 categories and "Некатегоризирани" are selected
+    And the "Избери всички" button in the Категории section is disabled
     When I click "Запази"
     Then my preferences are saved with all categories selected
 
@@ -77,9 +78,20 @@ Feature: Notification Filters
     When I navigate to "/settings/notification-filters"
     And I click "Изчисти всички" in the Категории section
     Then no categories are selected
+    And the "Изчисти всички" button in the Категории section is disabled
     When I click "Запази"
     Then my notification preferences are saved with categories []
     And all future messages pass the category filter (no restriction)
+
+  Scenario: "Избери всички" button is disabled when all categories are already selected
+    Given I have notification category filter set to all categories
+    When I navigate to "/settings/notification-filters"
+    Then the "Избери всички" button in the Категории section is disabled
+
+  Scenario: "Изчисти всички" button is disabled when no categories are selected
+    Given I have no notification filter preferences saved
+    When I navigate to "/settings/notification-filters"
+    Then the "Изчисти всички" button in the Категории section is disabled
 
   # ─── Source Filtering ────────────────────────────────────────────────
 
@@ -100,6 +112,7 @@ Feature: Notification Filters
     When I navigate to "/settings/notification-filters"
     And I click "Избери всички" in the Източници section
     Then all sources for my locality are selected
+    And the "Избери всички" button in the Източници section is disabled
 
   Scenario: Deselect all sources
     Given I have notification source filter set to ["sofiyska-voda", "toplo-bg"]
@@ -108,6 +121,16 @@ Feature: Notification Filters
     And I click "Запази"
     Then my notification preferences are saved with sources []
     And all future messages pass the source filter (no restriction)
+
+  Scenario: "Избери всички" button is disabled when all sources are already selected
+    Given I have notification source filter set to all sources for my locality
+    When I navigate to "/settings/notification-filters"
+    Then the "Избери всички" button in the Източници section is disabled
+
+  Scenario: "Изчисти всички" button is disabled when no sources are selected
+    Given I have no notification filter preferences saved
+    When I navigate to "/settings/notification-filters"
+    Then the "Изчисти всички" button in the Източници section is disabled
 
   # ─── Combined Filters ───────────────────────────────────────────────
 
@@ -131,6 +154,19 @@ Feature: Notification Filters
     Then I am navigated away from the filters page
     When I navigate back to "/settings/notification-filters"
     Then only "Вода" is selected in categories
+
+  Scenario: Browser warns when navigating away with unsaved changes
+    Given I have no notification filter preferences saved
+    When I navigate to "/settings/notification-filters"
+    And I select the "Вода" category
+    And I try to close the browser tab without saving
+    Then I see a browser confirmation dialog warning me about unsaved changes
+
+  Scenario: Browser does not warn when there are no unsaved changes
+    Given I have no notification filter preferences saved
+    When I navigate to "/settings/notification-filters"
+    And I try to close the browser tab without making any changes
+    Then I do not see a browser confirmation dialog
 
   Scenario: Clear all filters removes all active filters
     Given I have notification category filter set to ["water", "electricity"]

--- a/ingest/notifications/match-and-notify.ts
+++ b/ingest/notifications/match-and-notify.ts
@@ -189,13 +189,19 @@ export async function main(): Promise<void> {
   const allPrefs = await db.userPreferences.findByUserIds(uniqueUserIds);
   for (const prefs of allPrefs) {
     const userId = prefs.userId as string;
-    const cats = (prefs.notificationCategories as string[]) ?? [];
-    const srcs = (prefs.notificationSources as string[]) ?? [];
+    const rawCats = prefs.notificationCategories;
+    const cats = Array.isArray(rawCats)
+      ? rawCats.filter((v): v is string => typeof v === "string")
+      : [];
+    const rawSrcs = prefs.notificationSources;
+    const srcs = Array.isArray(rawSrcs)
+      ? rawSrcs.filter((v): v is string => typeof v === "string")
+      : [];
     // Only add to map if user actually has active filters
     if (cats.length > 0 || srcs.length > 0) {
       userFiltersMap.set(userId, {
-        notificationCategories: cats,
-        notificationSources: srcs,
+        notificationCategories: new Set(cats),
+        notificationSources: new Set(srcs),
       });
     }
   }

--- a/ingest/notifications/match-and-notify.ts
+++ b/ingest/notifications/match-and-notify.ts
@@ -182,22 +182,21 @@ export async function main(): Promise<void> {
     return;
   }
 
-  // Step 3: Load user notification filter preferences
+  // Step 3: Load user notification filter preferences (batch query to avoid N+1)
   const uniqueUserIds = [...new Set(interests.map((i) => i.userId))];
   const userFiltersMap = new Map<string, UserNotificationFilters>();
 
-  for (const userId of uniqueUserIds) {
-    const prefs = await db.userPreferences.findByUserId(userId);
-    if (prefs) {
-      const cats = (prefs.notificationCategories as string[]) ?? [];
-      const srcs = (prefs.notificationSources as string[]) ?? [];
-      // Only add to map if user actually has active filters
-      if (cats.length > 0 || srcs.length > 0) {
-        userFiltersMap.set(userId, {
-          notificationCategories: cats,
-          notificationSources: srcs,
-        });
-      }
+  const allPrefs = await db.userPreferences.findByUserIds(uniqueUserIds);
+  for (const prefs of allPrefs) {
+    const userId = prefs.userId as string;
+    const cats = (prefs.notificationCategories as string[]) ?? [];
+    const srcs = (prefs.notificationSources as string[]) ?? [];
+    // Only add to map if user actually has active filters
+    if (cats.length > 0 || srcs.length > 0) {
+      userFiltersMap.set(userId, {
+        notificationCategories: cats,
+        notificationSources: srcs,
+      });
     }
   }
 

--- a/ingest/notifications/match-and-notify.ts
+++ b/ingest/notifications/match-and-notify.ts
@@ -16,6 +16,7 @@ import {
   storeNotificationMatches,
   getUnnotifiedMatches,
 } from "./match-processor";
+import type { UserNotificationFilters } from "./match-processor";
 import {
   sendToUserDevices,
   updateMatchWithResults,
@@ -181,10 +182,37 @@ export async function main(): Promise<void> {
     return;
   }
 
-  // Step 3: Match messages with interests
+  // Step 3: Load user notification filter preferences
+  const uniqueUserIds = [...new Set(interests.map((i) => i.userId))];
+  const userFiltersMap = new Map<string, UserNotificationFilters>();
+
+  for (const userId of uniqueUserIds) {
+    const prefs = await db.userPreferences.findByUserId(userId);
+    if (prefs) {
+      const cats = (prefs.notificationCategories as string[]) ?? [];
+      const srcs = (prefs.notificationSources as string[]) ?? [];
+      // Only add to map if user actually has active filters
+      if (cats.length > 0 || srcs.length > 0) {
+        userFiltersMap.set(userId, {
+          notificationCategories: cats,
+          notificationSources: srcs,
+        });
+      }
+    }
+  }
+
+  if (userFiltersMap.size > 0) {
+    logger.info("Loaded user notification filters", {
+      usersWithFilters: userFiltersMap.size,
+      totalUsers: uniqueUserIds.length,
+    });
+  }
+
+  // Step 4: Match messages with interests (applying user filters)
   const matches = await matchMessagesWithInterests(
     unprocessedMessages,
     interests,
+    userFiltersMap,
   );
 
   if (matches.length === 0) {
@@ -197,13 +225,13 @@ export async function main(): Promise<void> {
     return;
   }
 
-  // Step 4: Deduplicate matches
+  // Step 5: Deduplicate matches
   const dedupedMatches = deduplicateMatches(matches);
 
-  // Step 5: Store matches in database
+  // Step 6: Store matches in database
   await storeNotificationMatches(db, dedupedMatches);
 
-  // Step 6: Get all unnotified matches (including ones we just stored)
+  // Step 7: Get all unnotified matches (including ones we just stored)
   const unnotifiedMatches = await getUnnotifiedMatches(db);
 
   if (unnotifiedMatches.length === 0) {
@@ -216,10 +244,10 @@ export async function main(): Promise<void> {
     return;
   }
 
-  // Step 7: Send notifications
+  // Step 8: Send notifications
   await sendNotifications(db, messaging, unnotifiedMatches);
 
-  // Step 8: Mark messages as having notifications sent
+  // Step 9: Mark messages as having notifications sent
   const messageIds = unprocessedMessages
     .map((m) => m.id)
     .filter((id): id is string => !!id);

--- a/ingest/notifications/match-and-notify.ts
+++ b/ingest/notifications/match-and-notify.ts
@@ -188,7 +188,7 @@ export async function main(): Promise<void> {
 
   const allPrefs = await db.userPreferences.findByUserIds(uniqueUserIds);
   for (const prefs of allPrefs) {
-    const userId = prefs.userId as string;
+    const userId = prefs._id as string;
     const rawCats = prefs.notificationCategories;
     const cats = Array.isArray(rawCats)
       ? rawCats.filter((v): v is string => typeof v === "string")

--- a/ingest/notifications/match-processor.test.ts
+++ b/ingest/notifications/match-processor.test.ts
@@ -110,8 +110,8 @@ describe("match-processor", () => {
 
     it("should allow all when both filter arrays are empty", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: [],
-        notificationSources: [],
+        notificationCategories: new Set(),
+        notificationSources: new Set(),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -124,8 +124,8 @@ describe("match-processor", () => {
     // Category filtering
     it("should allow message when its category matches the filter", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: [],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -137,8 +137,8 @@ describe("match-processor", () => {
 
     it("should reject message when its category does not match", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: [],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -150,8 +150,8 @@ describe("match-processor", () => {
 
     it("should allow message when any of its categories match", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: [],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -163,8 +163,8 @@ describe("match-processor", () => {
 
     it("should allow uncategorized messages when 'uncategorized' is selected", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["uncategorized"],
-        notificationSources: [],
+        notificationCategories: new Set(["uncategorized"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, { categories: [], source: "sofia-bg" }),
@@ -173,8 +173,8 @@ describe("match-processor", () => {
 
     it("should allow uncategorized messages when categories is undefined", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["uncategorized"],
-        notificationSources: [],
+        notificationCategories: new Set(["uncategorized"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -186,8 +186,8 @@ describe("match-processor", () => {
 
     it("should reject uncategorized messages when 'uncategorized' is not selected", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: [],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set([]),
       };
       expect(
         shouldNotifyUser(filters, { categories: [], source: "sofia-bg" }),
@@ -197,8 +197,8 @@ describe("match-processor", () => {
     // Source filtering
     it("should allow message when its source matches the filter", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: [],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set([]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -210,8 +210,8 @@ describe("match-processor", () => {
 
     it("should reject message when its source does not match", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: [],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set([]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -223,8 +223,8 @@ describe("match-processor", () => {
 
     it("should reject message when source is undefined and source filter is active", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: [],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set([]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, { categories: ["water"], source: undefined }),
@@ -234,8 +234,8 @@ describe("match-processor", () => {
     // Combined filtering
     it("should allow when both category and source match", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -247,8 +247,8 @@ describe("match-processor", () => {
 
     it("should reject when category matches but source does not", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, {
@@ -260,8 +260,8 @@ describe("match-processor", () => {
 
     it("should reject when source matches but category does not", () => {
       const filters: UserNotificationFilters = {
-        notificationCategories: ["water"],
-        notificationSources: ["sofiyska-voda"],
+        notificationCategories: new Set(["water"]),
+        notificationSources: new Set(["sofiyska-voda"]),
       };
       expect(
         shouldNotifyUser(filters, {

--- a/ingest/notifications/match-processor.test.ts
+++ b/ingest/notifications/match-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { deduplicateMatches } from "./match-processor";
-import type { MatchResult } from "./match-processor";
+import { deduplicateMatches, shouldNotifyUser } from "./match-processor";
+import type { MatchResult, UserNotificationFilters } from "./match-processor";
 
 describe("match-processor", () => {
   describe("deduplicateMatches", () => {
@@ -95,6 +95,180 @@ describe("match-processor", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(matches[0]);
+    });
+  });
+
+  describe("shouldNotifyUser", () => {
+    it("should allow all when filters are undefined", () => {
+      expect(
+        shouldNotifyUser(undefined, {
+          categories: ["water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    it("should allow all when both filter arrays are empty", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: [],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    // Category filtering
+    it("should allow message when its category matches the filter", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    it("should reject message when its category does not match", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["electricity"],
+          source: "erm-zapad",
+        }),
+      ).toBe(false);
+    });
+
+    it("should allow message when any of its categories match", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["construction-and-repairs", "water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    it("should allow uncategorized messages when 'uncategorized' is selected", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["uncategorized"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, { categories: [], source: "sofia-bg" }),
+      ).toBe(true);
+    });
+
+    it("should allow uncategorized messages when categories is undefined", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["uncategorized"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: undefined,
+          source: "sofia-bg",
+        }),
+      ).toBe(true);
+    });
+
+    it("should reject uncategorized messages when 'uncategorized' is not selected", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: [],
+      };
+      expect(
+        shouldNotifyUser(filters, { categories: [], source: "sofia-bg" }),
+      ).toBe(false);
+    });
+
+    // Source filtering
+    it("should allow message when its source matches the filter", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: [],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    it("should reject message when its source does not match", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: [],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["heating"],
+          source: "toplo-bg",
+        }),
+      ).toBe(false);
+    });
+
+    it("should reject message when source is undefined and source filter is active", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: [],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, { categories: ["water"], source: undefined }),
+      ).toBe(false);
+    });
+
+    // Combined filtering
+    it("should allow when both category and source match", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["water"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(true);
+    });
+
+    it("should reject when category matches but source does not", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["water"],
+          source: "toplo-bg",
+        }),
+      ).toBe(false);
+    });
+
+    it("should reject when source matches but category does not", () => {
+      const filters: UserNotificationFilters = {
+        notificationCategories: ["water"],
+        notificationSources: ["sofiyska-voda"],
+      };
+      expect(
+        shouldNotifyUser(filters, {
+          categories: ["electricity"],
+          source: "sofiyska-voda",
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/ingest/notifications/match-processor.ts
+++ b/ingest/notifications/match-processor.ts
@@ -2,6 +2,7 @@ import type { OboDb } from "@oboapp/db";
 import type { Message, Interest, NotificationMatch } from "@/lib/types";
 import { matchMessageToInterest } from "./geo-matcher";
 import { logger } from "@/lib/logger";
+import { UNCATEGORIZED } from "@oboapp/shared";
 
 export interface MatchResult {
   messageId: string;
@@ -13,9 +14,9 @@ export interface MatchResult {
 /** User notification filter preferences (loaded from userPreferences collection) */
 export interface UserNotificationFilters {
   /** Categories to include (empty = allow all). May contain "uncategorized". */
-  notificationCategories: string[];
+  notificationCategories: Set<string>;
   /** Sources to include (empty = allow all) */
-  notificationSources: string[];
+  notificationSources: Set<string>;
 }
 
 /**
@@ -38,26 +39,26 @@ export function shouldNotifyUser(
   const { notificationCategories, notificationSources } = filters;
 
   // Check category filter
-  if (notificationCategories.length > 0) {
+  if (notificationCategories.size > 0) {
     const messageCategories = message.categories ?? [];
 
     if (messageCategories.length === 0) {
       // Message has no categories → only passes if "uncategorized" is selected
-      if (!notificationCategories.includes("uncategorized")) {
+      if (!notificationCategories.has(UNCATEGORIZED)) {
         return false;
       }
     } else {
       // Message has categories → at least one must be in the filter set
       const hasMatch = messageCategories.some((cat) =>
-        notificationCategories.includes(cat),
+        notificationCategories.has(cat),
       );
       if (!hasMatch) return false;
     }
   }
 
   // Check source filter
-  if (notificationSources.length > 0) {
-    if (!message.source || !notificationSources.includes(message.source)) {
+  if (notificationSources.size > 0) {
+    if (!message.source || !notificationSources.has(message.source)) {
       return false;
     }
   }

--- a/ingest/notifications/match-processor.ts
+++ b/ingest/notifications/match-processor.ts
@@ -10,12 +10,118 @@ export interface MatchResult {
   distance: number;
 }
 
+/** User notification filter preferences (loaded from userPreferences collection) */
+export interface UserNotificationFilters {
+  /** Categories to include (empty = allow all). May contain "uncategorized". */
+  notificationCategories: string[];
+  /** Sources to include (empty = allow all) */
+  notificationSources: string[];
+}
+
 /**
- * Match unprocessed messages with user interests
+ * Determine whether a message passes a user's notification filters.
+ *
+ * Rules:
+ * - Empty filter array for a dimension = no restriction (allow all)
+ * - Non-empty categories: message must have at least one matching category,
+ *   OR "uncategorized" is selected and message has no categories
+ * - Non-empty sources: message source must be in the set
+ * - Both dimensions must pass (AND logic)
+ */
+export function shouldNotifyUser(
+  filters: UserNotificationFilters | undefined,
+  message: Pick<Message, "categories" | "source">,
+): boolean {
+  // No preferences doc → no filtering → allow all
+  if (!filters) return true;
+
+  const { notificationCategories, notificationSources } = filters;
+
+  // Check category filter
+  if (notificationCategories.length > 0) {
+    const messageCategories = message.categories ?? [];
+
+    if (messageCategories.length === 0) {
+      // Message has no categories → only passes if "uncategorized" is selected
+      if (!notificationCategories.includes("uncategorized")) {
+        return false;
+      }
+    } else {
+      // Message has categories → at least one must be in the filter set
+      const hasMatch = messageCategories.some((cat) =>
+        notificationCategories.includes(cat),
+      );
+      if (!hasMatch) return false;
+    }
+  }
+
+  // Check source filter
+  if (notificationSources.length > 0) {
+    if (!message.source || !notificationSources.includes(message.source)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check if a message passes a user's notification filters.
+ * Returns true if user has no filters or if the message passes them.
+ */
+function passesUserFilters(
+  filtersMap: Map<string, UserNotificationFilters> | undefined,
+  userId: string,
+  message: Pick<Message, "categories" | "source">,
+): boolean {
+  if (!filtersMap) return true;
+  return shouldNotifyUser(filtersMap.get(userId), message);
+}
+
+/**
+ * Check if a message-interest pair should produce a match.
+ * Returns a MatchResult if the pair passes all checks, or null otherwise.
+ */
+function tryMatchPair(
+  message: Message,
+  interest: Interest,
+  userFiltersMap?: Map<string, UserNotificationFilters>,
+): MatchResult | null {
+  if (!interest.id) return null;
+
+  // Only match if the message was created after the interest was created
+  if (message.createdAt < interest.createdAt) return null;
+
+  const { matches: isMatch, distance } = matchMessageToInterest(
+    message,
+    interest,
+  );
+
+  if (!isMatch || distance === null) return null;
+
+  // Check user's notification filters before recording the match
+  if (!passesUserFilters(userFiltersMap, interest.userId, message)) {
+    return null;
+  }
+
+  return {
+    messageId: message.id!,
+    userId: interest.userId,
+    interestId: interest.id,
+    distance,
+  };
+}
+
+/**
+ * Match unprocessed messages with user interests.
+ *
+ * When userFiltersMap is provided, messages that don't pass a user's
+ * notification filters are skipped (no match record created).
  */
 export async function matchMessagesWithInterests(
   messages: Message[],
   interests: Interest[],
+  userFiltersMap?: Map<string, UserNotificationFilters>,
 ): Promise<MatchResult[]> {
   logger.info("Matching messages with interests");
 
@@ -27,33 +133,14 @@ export async function matchMessagesWithInterests(
     }
 
     for (const interest of interests) {
-      if (!interest.id) {
-        continue;
-      }
-
-      // Only match if the message was created after the interest was created
-      // Both message.createdAt and interest.createdAt are ISO strings
-      if (message.createdAt < interest.createdAt) {
-        continue;
-      }
-
-      const { matches: isMatch, distance } = matchMessageToInterest(
-        message,
-        interest,
-      );
-
-      if (isMatch && distance !== null) {
-        matches.push({
-          messageId: message.id,
-          userId: interest.userId,
-          interestId: interest.id,
-          distance,
-        });
+      const match = tryMatchPair(message, interest, userFiltersMap);
+      if (match) {
+        matches.push(match);
         logger.info("Match found", {
-          messageId: message.id.substring(0, 8),
-          userId: interest.userId.substring(0, 8),
-          interestId: interest.id.substring(0, 8),
-          distanceMeters: Math.round(distance),
+          messageId: match.messageId.substring(0, 8),
+          userId: match.userId.substring(0, 8),
+          interestId: match.interestId.substring(0, 8),
+          distanceMeters: Math.round(match.distance),
         });
       }
     }
@@ -128,7 +215,11 @@ export async function getUnnotifiedMatches(
 
   const matches: NotificationMatch[] = docs.map((data) => {
     const toStr = (v: unknown): string =>
-      v instanceof Date ? v.toISOString() : typeof v === "string" ? v : new Date().toISOString();
+      v instanceof Date
+        ? v.toISOString()
+        : typeof v === "string"
+          ? v
+          : new Date().toISOString();
 
     return {
       id: data._id as string,

--- a/ingest/notifications/message-fetcher.ts
+++ b/ingest/notifications/message-fetcher.ts
@@ -31,7 +31,9 @@ export async function getUnprocessedMessages(db: OboDb): Promise<Message[]> {
         createdAt: toISOString(data.createdAt),
         cityWide: data.cityWide as boolean | undefined,
         source: data.source as string | undefined,
-        categories: (data.categories as Category[]) || undefined,
+        categories: Array.isArray(data.categories)
+          ? (data.categories as Category[])
+          : undefined,
       });
     }
   }

--- a/ingest/notifications/message-fetcher.ts
+++ b/ingest/notifications/message-fetcher.ts
@@ -1,4 +1,5 @@
 import type { OboDb } from "@oboapp/db";
+import type { Category } from "@oboapp/shared";
 import { Message } from "@/lib/types";
 import { logger } from "@/lib/logger";
 
@@ -11,9 +12,7 @@ function toISOString(value: unknown): string {
 /**
  * Get all unprocessed messages (messages without notificationsSent flag)
  */
-export async function getUnprocessedMessages(
-  db: OboDb,
-): Promise<Message[]> {
+export async function getUnprocessedMessages(db: OboDb): Promise<Message[]> {
   logger.info("Fetching unprocessed messages");
 
   const docs = await db.messages.findMany({
@@ -31,11 +30,15 @@ export async function getUnprocessedMessages(
         geoJson: data.geoJson as Message["geoJson"],
         createdAt: toISOString(data.createdAt),
         cityWide: data.cityWide as boolean | undefined,
+        source: data.source as string | undefined,
+        categories: (data.categories as Category[]) || undefined,
       });
     }
   }
 
-  logger.info("Found unprocessed messages", { count: unprocessedMessages.length });
+  logger.info("Found unprocessed messages", {
+    count: unprocessedMessages.length,
+  });
 
   return unprocessedMessages;
 }

--- a/shared/src/schema/index.ts
+++ b/shared/src/schema/index.ts
@@ -14,6 +14,7 @@ export * from "./pin.schema";
 export * from "./source.schema";
 export * from "./street-section.schema";
 export * from "./timespan.schema";
+export * from "./user-preferences.schema";
 
 // Re-export the zod instance
 export { z } from "zod";

--- a/shared/src/schema/user-preferences.schema.ts
+++ b/shared/src/schema/user-preferences.schema.ts
@@ -5,10 +5,11 @@ import { CategoryEnum } from "./category.schema";
  * Allowed values for notification category filters.
  * Includes all real categories plus "uncategorized" for messages without categories.
  */
-const NotificationCategoryEnum = z.enum([
+const notificationCategoryValues = [
   ...CategoryEnum.options,
   "uncategorized",
-]);
+] as const;
+const NotificationCategoryEnum = z.enum(notificationCategoryValues);
 
 export const UserPreferencesSchema = z.object({
   id: z.string(),

--- a/shared/src/schema/user-preferences.schema.ts
+++ b/shared/src/schema/user-preferences.schema.ts
@@ -1,0 +1,33 @@
+import { z } from "../zod-openapi";
+import { CategoryEnum } from "./category.schema";
+
+/**
+ * Allowed values for notification category filters.
+ * Includes all real categories plus "uncategorized" for messages without categories.
+ */
+const NotificationCategoryEnum = z.enum([
+  ...CategoryEnum.options,
+  "uncategorized",
+]);
+
+export const UserPreferencesSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  /** Categories to include in notifications (empty = allow all) */
+  notificationCategories: z.array(NotificationCategoryEnum).default([]),
+  /** Sources to include in notifications (empty = allow all) */
+  notificationSources: z.array(z.string()).default([]),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** Schema for PUT request body (only the filter fields) */
+export const UserPreferencesRequestSchema = z.object({
+  notificationCategories: z.array(NotificationCategoryEnum).default([]),
+  notificationSources: z.array(z.string()).default([]),
+});
+
+export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
+export type UserPreferencesRequest = z.infer<
+  typeof UserPreferencesRequestSchema
+>;

--- a/web/__mocks__/handlers.ts
+++ b/web/__mocks__/handlers.ts
@@ -4,7 +4,11 @@ import { MOCK_INTERESTS, MOCK_USER_ID } from "./fixtures/interests";
 import { MOCK_SUBSCRIPTIONS } from "./fixtures/subscriptions";
 import { MOCK_NOTIFICATION_HISTORY } from "./fixtures/notification-history";
 import { MOCK_API_CLIENT } from "./fixtures/api-client";
-import type { Interest, NotificationSubscription, ApiClient } from "@/lib/types";
+import type {
+  Interest,
+  NotificationSubscription,
+  ApiClient,
+} from "@/lib/types";
 import type { Message } from "@oboapp/shared";
 
 /**
@@ -17,6 +21,10 @@ let interests: Interest[] = [...MOCK_INTERESTS];
 let subscriptions: NotificationSubscription[] = [...MOCK_SUBSCRIPTIONS];
 let apiClient: ApiClient | null = null; // Start with no API client
 let notificationHistory = [...MOCK_NOTIFICATION_HISTORY];
+let notificationFilters = {
+  notificationCategories: [] as string[],
+  notificationSources: [] as string[],
+};
 
 /**
  * Helper: Filter messages by viewport bounds
@@ -324,10 +332,37 @@ export const handlers = [
     return HttpResponse.json({ success: true, deleted });
   }),
 
+  // GET /api/notifications/filters - Get notification filter preferences
+  http.get("/api/notifications/filters", () => {
+    return HttpResponse.json(notificationFilters);
+  }),
+
+  // PUT /api/notifications/filters - Save notification filter preferences
+  http.put("/api/notifications/filters", async ({ request }) => {
+    const body = (await request.json()) as {
+      notificationCategories?: string[];
+      notificationSources?: string[];
+    };
+    notificationFilters = {
+      notificationCategories: body.notificationCategories ?? [],
+      notificationSources: body.notificationSources ?? [],
+    };
+    return HttpResponse.json(notificationFilters);
+  }),
+
+  // DELETE /api/notifications/filters - Clear notification filter preferences
+  http.delete("/api/notifications/filters", () => {
+    notificationFilters = {
+      notificationCategories: [],
+      notificationSources: [],
+    };
+    return HttpResponse.json(notificationFilters);
+  }),
+
   // GET /api/notifications/history - Fetch notification history with pagination
   http.get("/api/notifications/history", ({ request }) => {
     const url = new URL(request.url);
-    
+
     const rawLimit = url.searchParams.get("limit");
     let limit = Number.parseInt(rawLimit ?? "", 10);
     if (!Number.isFinite(limit) || limit <= 0) {
@@ -402,6 +437,10 @@ export const handlers = [
     subscriptions = [];
     apiClient = null;
     notificationHistory = [];
+    notificationFilters = {
+      notificationCategories: [],
+      notificationSources: [],
+    };
     return new HttpResponse(null, { status: 204 });
   }),
 
@@ -414,7 +453,10 @@ export const handlers = [
   http.post("/api/api-clients", async ({ request }) => {
     if (apiClient) {
       return HttpResponse.json(
-        { error: "You already have an API key. Revoke it first to generate a new one." },
+        {
+          error:
+            "You already have an API key. Revoke it first to generate a new one.",
+        },
         { status: 409 },
       );
     }
@@ -435,7 +477,10 @@ export const handlers = [
   // DELETE /api/api-clients - Revoke current user's API key
   http.delete("/api/api-clients", () => {
     if (!apiClient) {
-      return HttpResponse.json({ error: "No API client found" }, { status: 404 });
+      return HttpResponse.json(
+        { error: "No API client found" },
+        { status: 404 },
+      );
     }
     apiClient = null;
     return HttpResponse.json({ success: true });

--- a/web/app/api/notifications/filters/__tests__/route.test.ts
+++ b/web/app/api/notifications/filters/__tests__/route.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, PUT, DELETE } from "../route";
+
+const { findByUserIdMock, upsertByUserIdMock, updateOneMock } = vi.hoisted(
+  () => ({
+    findByUserIdMock: vi.fn(),
+    upsertByUserIdMock: vi.fn(),
+    updateOneMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn().mockResolvedValue({
+    userPreferences: {
+      findByUserId: findByUserIdMock,
+      upsertByUserId: upsertByUserIdMock,
+      updateOne: updateOneMock,
+    },
+  }),
+}));
+
+const { verifyAuthTokenMock } = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/verifyAuthToken", () => ({
+  verifyAuthToken: verifyAuthTokenMock,
+}));
+
+describe("GET /api/notifications/filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifyAuthTokenMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("returns empty filters when no preferences document exists", async () => {
+    findByUserIdMock.mockResolvedValue(null);
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      { headers: { authorization: "Bearer test-token" } },
+    );
+
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      notificationCategories: [],
+      notificationSources: [],
+    });
+  });
+
+  it("returns saved filter preferences", async () => {
+    findByUserIdMock.mockResolvedValue({
+      _id: "prefs-1",
+      userId: "user-1",
+      notificationCategories: ["water", "electricity"],
+      notificationSources: ["sofiyska-voda"],
+    });
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      { headers: { authorization: "Bearer test-token" } },
+    );
+
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      notificationCategories: ["water", "electricity"],
+      notificationSources: ["sofiyska-voda"],
+    });
+  });
+
+  it("returns 401 when auth token is missing", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Missing auth token"));
+
+    const request = new Request("http://localhost/api/notifications/filters");
+
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when auth token is invalid", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Invalid auth token"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      { headers: { authorization: "Bearer bad-token" } },
+    );
+
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 500 when database fails", async () => {
+    findByUserIdMock.mockRejectedValue(new Error("DB connection failed"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      { headers: { authorization: "Bearer test-token" } },
+    );
+
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch notification filters");
+  });
+});
+
+describe("PUT /api/notifications/filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifyAuthTokenMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("saves valid filter preferences", async () => {
+    upsertByUserIdMock.mockResolvedValue(undefined);
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          notificationCategories: ["water"],
+          notificationSources: ["sofiyska-voda"],
+        }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      notificationCategories: ["water"],
+      notificationSources: ["sofiyska-voda"],
+    });
+    expect(upsertByUserIdMock).toHaveBeenCalledWith("user-1", {
+      notificationCategories: ["water"],
+      notificationSources: ["sofiyska-voda"],
+    });
+  });
+
+  it("saves empty filter arrays (reset all filters)", async () => {
+    upsertByUserIdMock.mockResolvedValue(undefined);
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          notificationCategories: [],
+          notificationSources: [],
+        }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ notificationCategories: [], notificationSources: [] });
+  });
+
+  it("returns 400 for invalid category value", async () => {
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          notificationCategories: ["not-a-valid-category"],
+          notificationSources: [],
+        }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid request body");
+  });
+
+  it("returns 401 when auth token is missing", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Missing auth token"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notificationCategories: [], notificationSources: [] }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when auth token is invalid", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Invalid auth token"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer bad-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ notificationCategories: [], notificationSources: [] }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 500 when database fails", async () => {
+    upsertByUserIdMock.mockRejectedValue(new Error("DB connection failed"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ notificationCategories: [], notificationSources: [] }),
+      },
+    );
+
+    const response = await PUT(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to save notification filters");
+  });
+});
+
+describe("DELETE /api/notifications/filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifyAuthTokenMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("clears filters when preferences document exists", async () => {
+    findByUserIdMock.mockResolvedValue({
+      _id: "prefs-1",
+      userId: "user-1",
+      notificationCategories: ["water"],
+      notificationSources: ["sofiyska-voda"],
+    });
+    updateOneMock.mockResolvedValue(undefined);
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "DELETE",
+        headers: { authorization: "Bearer test-token" },
+      },
+    );
+
+    const response = await DELETE(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ notificationCategories: [], notificationSources: [] });
+    expect(updateOneMock).toHaveBeenCalledWith("prefs-1", {
+      notificationCategories: [],
+      notificationSources: [],
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("returns empty filters gracefully when no preferences document exists", async () => {
+    findByUserIdMock.mockResolvedValue(null);
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "DELETE",
+        headers: { authorization: "Bearer test-token" },
+      },
+    );
+
+    const response = await DELETE(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ notificationCategories: [], notificationSources: [] });
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when auth token is missing", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Missing auth token"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      { method: "DELETE" },
+    );
+
+    const response = await DELETE(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when auth token is invalid", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("Invalid auth token"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "DELETE",
+        headers: { authorization: "Bearer bad-token" },
+      },
+    );
+
+    const response = await DELETE(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 500 when database fails", async () => {
+    findByUserIdMock.mockRejectedValue(new Error("DB connection failed"));
+
+    const request = new Request(
+      "http://localhost/api/notifications/filters",
+      {
+        method: "DELETE",
+        headers: { authorization: "Bearer test-token" },
+      },
+    );
+
+    const response = await DELETE(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to clear notification filters");
+  });
+});

--- a/web/app/api/notifications/filters/__tests__/route.test.ts
+++ b/web/app/api/notifications/filters/__tests__/route.test.ts
@@ -271,17 +271,10 @@ describe("DELETE /api/notifications/filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     verifyAuthTokenMock.mockResolvedValue({ userId: "user-1" });
+    upsertByUserIdMock.mockResolvedValue("user-1");
   });
 
-  it("clears filters when preferences document exists", async () => {
-    findByUserIdMock.mockResolvedValue({
-      _id: "prefs-1",
-      userId: "user-1",
-      notificationCategories: ["water"],
-      notificationSources: ["sofiyska-voda"],
-    });
-    updateOneMock.mockResolvedValue(undefined);
-
+  it("clears filters for a user", async () => {
     const request = new Request(
       "http://localhost/api/notifications/filters",
       {
@@ -295,30 +288,10 @@ describe("DELETE /api/notifications/filters", () => {
 
     expect(response.status).toBe(200);
     expect(data).toEqual({ notificationCategories: [], notificationSources: [] });
-    expect(updateOneMock).toHaveBeenCalledWith("prefs-1", {
+    expect(upsertByUserIdMock).toHaveBeenCalledWith("user-1", {
       notificationCategories: [],
       notificationSources: [],
-      updatedAt: expect.any(Date),
     });
-  });
-
-  it("returns empty filters gracefully when no preferences document exists", async () => {
-    findByUserIdMock.mockResolvedValue(null);
-
-    const request = new Request(
-      "http://localhost/api/notifications/filters",
-      {
-        method: "DELETE",
-        headers: { authorization: "Bearer test-token" },
-      },
-    );
-
-    const response = await DELETE(request as any);
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(data).toEqual({ notificationCategories: [], notificationSources: [] });
-    expect(updateOneMock).not.toHaveBeenCalled();
   });
 
   it("returns 401 when auth token is missing", async () => {
@@ -355,7 +328,7 @@ describe("DELETE /api/notifications/filters", () => {
   });
 
   it("returns 500 when database fails", async () => {
-    findByUserIdMock.mockRejectedValue(new Error("DB connection failed"));
+    upsertByUserIdMock.mockRejectedValue(new Error("DB connection failed"));
 
     const request = new Request(
       "http://localhost/api/notifications/filters",

--- a/web/app/api/notifications/filters/route.ts
+++ b/web/app/api/notifications/filters/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
       notificationSources: (prefs.notificationSources as string[]) ?? [],
     });
   } catch (error) {
-    if (error instanceof Error && error.message === "Missing auth token") {
+    if (error instanceof Error && (error.message === "Missing auth token" || error.message === "Invalid auth token")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     console.error("Error fetching notification filters:", error);
@@ -62,7 +62,7 @@ export async function PUT(request: NextRequest) {
       notificationSources: parsed.data.notificationSources,
     });
   } catch (error) {
-    if (error instanceof Error && error.message === "Missing auth token") {
+    if (error instanceof Error && (error.message === "Missing auth token" || error.message === "Invalid auth token")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     console.error("Error saving notification filters:", error);
@@ -96,7 +96,7 @@ export async function DELETE(request: NextRequest) {
       notificationSources: [],
     });
   } catch (error) {
-    if (error instanceof Error && error.message === "Missing auth token") {
+    if (error instanceof Error && (error.message === "Missing auth token" || error.message === "Invalid auth token")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     console.error("Error clearing notification filters:", error);

--- a/web/app/api/notifications/filters/route.ts
+++ b/web/app/api/notifications/filters/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { verifyAuthToken } from "@/lib/verifyAuthToken";
+import { UserPreferencesRequestSchema } from "@oboapp/shared";
+
+/** GET — return current user's notification filter preferences */
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const { userId } = await verifyAuthToken(authHeader);
+
+    const db = await getDb();
+    const prefs = await db.userPreferences.findByUserId(userId);
+
+    if (!prefs) {
+      return NextResponse.json({
+        notificationCategories: [],
+        notificationSources: [],
+      });
+    }
+
+    return NextResponse.json({
+      notificationCategories: (prefs.notificationCategories as string[]) ?? [],
+      notificationSources: (prefs.notificationSources as string[]) ?? [],
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Missing auth token") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("Error fetching notification filters:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch notification filters" },
+      { status: 500 },
+    );
+  }
+}
+
+/** PUT — save notification filter preferences */
+export async function PUT(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const { userId } = await verifyAuthToken(authHeader);
+
+    const body = await request.json();
+    const parsed = UserPreferencesRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const db = await getDb();
+    await db.userPreferences.upsertByUserId(userId, {
+      notificationCategories: parsed.data.notificationCategories,
+      notificationSources: parsed.data.notificationSources,
+    });
+
+    return NextResponse.json({
+      notificationCategories: parsed.data.notificationCategories,
+      notificationSources: parsed.data.notificationSources,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Missing auth token") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("Error saving notification filters:", error);
+    return NextResponse.json(
+      { error: "Failed to save notification filters" },
+      { status: 500 },
+    );
+  }
+}
+
+/** DELETE — clear all notification filters (reset to no filtering) */
+export async function DELETE(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const { userId } = await verifyAuthToken(authHeader);
+
+    const db = await getDb();
+    const prefs = await db.userPreferences.findByUserId(userId);
+
+    if (prefs) {
+      const docId = prefs._id as string;
+      await db.userPreferences.updateOne(docId, {
+        notificationCategories: [],
+        notificationSources: [],
+        updatedAt: new Date(),
+      });
+    }
+
+    return NextResponse.json({
+      notificationCategories: [],
+      notificationSources: [],
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Missing auth token") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("Error clearing notification filters:", error);
+    return NextResponse.json(
+      { error: "Failed to clear notification filters" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/api/notifications/filters/route.ts
+++ b/web/app/api/notifications/filters/route.ts
@@ -20,8 +20,16 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({
-      notificationCategories: (prefs.notificationCategories as string[]) ?? [],
-      notificationSources: (prefs.notificationSources as string[]) ?? [],
+      notificationCategories: Array.isArray(prefs.notificationCategories)
+        ? prefs.notificationCategories.filter(
+            (v): v is string => typeof v === "string",
+          )
+        : [],
+      notificationSources: Array.isArray(prefs.notificationSources)
+        ? prefs.notificationSources.filter(
+            (v): v is string => typeof v === "string",
+          )
+        : [],
     });
   } catch (error) {
     if (error instanceof Error && (error.message === "Missing auth token" || error.message === "Invalid auth token")) {
@@ -80,16 +88,10 @@ export async function DELETE(request: NextRequest) {
     const { userId } = await verifyAuthToken(authHeader);
 
     const db = await getDb();
-    const prefs = await db.userPreferences.findByUserId(userId);
-
-    if (prefs) {
-      const docId = prefs._id as string;
-      await db.userPreferences.updateOne(docId, {
-        notificationCategories: [],
-        notificationSources: [],
-        updatedAt: new Date(),
-      });
-    }
+    await db.userPreferences.upsertByUserId(userId, {
+      notificationCategories: [],
+      notificationSources: [],
+    });
 
     return NextResponse.json({
       notificationCategories: [],

--- a/web/app/notifications/page.tsx
+++ b/web/app/notifications/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/notification-service";
 import { formatNotificationDateTime } from "@/lib/notification-history";
 import { useNotificationHistory } from "@/lib/hooks/useNotificationHistory";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 export default function NotificationsPage() {
   const { user } = useAuth();
@@ -75,7 +76,7 @@ export default function NotificationsPage() {
 
           <h1 className="text-3xl font-bold text-gray-900 mb-8">Известия</h1>
           <div className="flex justify-center items-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+            <LoadingSpinner size="lg" />
           </div>
         </div>
       </div>

--- a/web/app/settings/NotificationsSection.tsx
+++ b/web/app/settings/NotificationsSection.tsx
@@ -5,6 +5,9 @@ import SubscriptionCount from "./SubscriptionCount";
 import SubscribeDevicePrompt from "./SubscribeDevicePrompt";
 import DeviceSubscriptionCard from "./DeviceSubscriptionCard";
 import UnsubscribeAllButton from "./UnsubscribeAllButton";
+import Link from "next/link";
+import { buttonStyles, buttonSizes } from "@/lib/theme";
+import { borderRadius } from "@/lib/colors";
 
 interface NotificationsSectionProps {
   readonly subscriptions: NotificationSubscription[];
@@ -57,6 +60,19 @@ export default function NotificationsSection({
       {subscriptions.length > 1 && (
         <UnsubscribeAllButton onUnsubscribeAll={onUnsubscribeAll} />
       )}
+
+      {/* Notification Filters link */}
+      <div className="mt-4 pt-4 border-t border-neutral-border">
+        <Link
+          href="/settings/notification-filters"
+          className={`${buttonStyles.ghost} ${buttonSizes.md} ${borderRadius.sm} inline-block`}
+        >
+          Филтри за известия
+        </Link>
+        <p className="text-xs text-neutral mt-1">
+          Изберете от кои категории и източници искате да получавате известия.
+        </p>
+      </div>
     </section>
   );
 }

--- a/web/app/settings/SettingsHeader.tsx
+++ b/web/app/settings/SettingsHeader.tsx
@@ -1,15 +1,10 @@
-import Link from "next/link";
+import BackButton from "@/components/BackButton";
 
 export default function SettingsHeader() {
   return (
     <div className="mb-8">
-      <Link
-        href="/"
-        className="text-sm text-primary hover:text-primary-hover mb-4 inline-block"
-      >
-        ← Начало
-      </Link>
-      <h1 className="text-3xl font-bold text-gray-900">Настройки</h1>
+      <BackButton href="/" label="Начало" />
+      <h1 className="text-3xl font-bold text-gray-900 mt-4">Настройки</h1>
     </div>
   );
 }

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -17,6 +17,7 @@ import { borderRadius } from "@/lib/colors";
 import { ArrowLeft, Info } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useMemo } from "react";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 export default function NotificationFiltersPage() {
   const router = useRouter();
@@ -80,7 +81,7 @@ export default function NotificationFiltersPage() {
   if (authLoading || !user) {
     return (
       <div className="flex justify-center items-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        <LoadingSpinner />
       </div>
     );
   }
@@ -118,7 +119,7 @@ export default function NotificationFiltersPage() {
 
       {isLoading ? (
         <div className="flex justify-center items-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <LoadingSpinner />
         </div>
       ) : (
         <>

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -65,6 +65,18 @@ export default function NotificationFiltersPage() {
     }
   }, [authLoading, user, router]);
 
+  // Warn user if they try to navigate away with unsaved changes
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty]);
+
   const handleSave = async () => {
     const success = await save();
     if (success) {
@@ -122,8 +134,9 @@ export default function NotificationFiltersPage() {
             <div className="bg-white rounded-lg shadow mb-6">
               <FilterSection
                 title="Категории"
-                description="Изберете категориите, за които искате да получавате известия. Ако не изберете нищо, ще получавате известия от всички категории."
+                description="Избери категориите, за които искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия от всички категории."
                 hasActiveFilters={selectedCategories.size > 0}
+                allSelected={selectedCategories.size === allCategoryValues.length}
                 onSelectAll={() => selectAllCategories(allCategoryValues)}
                 onDeselectAll={deselectAllCategories}
               >
@@ -146,8 +159,9 @@ export default function NotificationFiltersPage() {
 
               <FilterSection
                 title="Източници"
-                description="Изберете източниците, от които искате да получавате известия. Ако не изберете нищо, ще получавате известия от всички източници."
+                description="Избери източниците, от които искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия от всички източници."
                 hasActiveFilters={selectedSources.size > 0}
+                allSelected={selectedSources.size === allSourceIds.length}
                 onSelectAll={() => selectAllSources(allSourceIds)}
                 onDeselectAll={deselectAllSources}
               >

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -134,7 +134,7 @@ export default function NotificationFiltersPage() {
             <div className="bg-white rounded-lg shadow mb-6">
               <FilterSection
                 title="Категории"
-                description="Избери категориите, за които искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия от всички категории."
+                description="Избери категориите, за които искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия за съобщения, попадащи в зоните ти на интерес от всички категории."
                 hasActiveFilters={selectedCategories.size > 0}
                 allSelected={selectedCategories.size === allCategoryValues.length}
                 onSelectAll={() => selectAllCategories(allCategoryValues)}
@@ -159,7 +159,7 @@ export default function NotificationFiltersPage() {
 
               <FilterSection
                 title="Източници"
-                description="Избери източниците, от които искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия от всички източници."
+                description="Избери от кои източници искаш да получаваш известия. Ако не избереш нищо, ще получаваш известия от всички източници за съобщения попадащи в зоните ти на интерес."
                 hasActiveFilters={selectedSources.size > 0}
                 allSelected={selectedSources.size === allSourceIds.length}
                 onSelectAll={() => selectAllSources(allSourceIds)}

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -102,7 +102,7 @@ export default function NotificationFiltersPage() {
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Back button */}
         <div className="mb-6">
-          <BackButton />
+          <BackButton href="/settings" label="Настройки" />
         </div>
 
         <h1 className="text-3xl font-bold text-gray-900 mb-8">

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+import { useNotificationFilters } from "@/lib/hooks/useNotificationFilters";
+import { getCurrentLocalitySources } from "@/lib/source-utils";
+import CategoryFilterItem from "@/components/CategoryFilterItem";
+import SourceFilterItem from "@/components/SourceFilterItem";
+import {
+  CATEGORY_DISPLAY_ORDER,
+  CATEGORY_LABELS,
+  UNCATEGORIZED,
+  UNCATEGORIZED_LABEL,
+} from "@oboapp/shared";
+import { buttonStyles, buttonSizes } from "@/lib/theme";
+import { borderRadius } from "@/lib/colors";
+import { ArrowLeft, Info } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo } from "react";
+
+export default function NotificationFiltersPage() {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+
+  const {
+    selectedCategories,
+    selectedSources,
+    isLoading,
+    isSaving,
+    error,
+    isDirty,
+    toggleCategory,
+    toggleSource,
+    selectAllCategories,
+    deselectAllCategories,
+    selectAllSources,
+    deselectAllSources,
+    save,
+    clearAll,
+    resetToSaved,
+  } = useNotificationFilters();
+
+  const sources = useMemo(() => {
+    try {
+      return getCurrentLocalitySources();
+    } catch {
+      return [];
+    }
+  }, []);
+
+  /** All category values including "uncategorized" */
+  const allCategoryValues = useMemo(
+    () => [...CATEGORY_DISPLAY_ORDER, UNCATEGORIZED],
+    [],
+  );
+
+  const allSourceIds = useMemo(() => sources.map((s) => s.id), [sources]);
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push("/");
+    }
+  }, [authLoading, user, router]);
+
+  const handleSave = async () => {
+    try {
+      await save();
+      router.push("/settings");
+    } catch {
+      // Error is shown via the hook's error state
+    }
+  };
+
+  const handleCancel = () => {
+    resetToSaved();
+    router.push("/settings");
+  };
+
+  if (authLoading || !user) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          href="/settings"
+          className="text-neutral hover:text-foreground transition-colors"
+          aria-label="Обратно към настройки"
+        >
+          <ArrowLeft size={24} />
+        </Link>
+        <h1 className="text-2xl font-bold text-foreground">
+          Филтри за известия
+        </h1>
+      </div>
+
+      {/* Info banner */}
+      <div className="flex items-start gap-3 p-4 mb-6 bg-info-light border border-info-border rounded-lg">
+        <Info size={20} className="text-info flex-shrink-0 mt-0.5" />
+        <p className="text-sm text-info">
+          Промените ще се приложат само за бъдещи известия. Вече получените
+          известия няма да бъдат засегнати.
+        </p>
+      </div>
+
+      {error && (
+        <div className="p-4 mb-6 bg-error-light border border-error-border rounded-lg text-error text-sm">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex justify-center items-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      ) : (
+        <>
+          {/* Categories Section */}
+          <section className="bg-white rounded-lg shadow mb-6 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-foreground">
+                Категории
+              </h2>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => selectAllCategories(allCategoryValues)}
+                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+                >
+                  Избери всички
+                </button>
+                <span className="text-neutral-border">|</span>
+                <button
+                  type="button"
+                  onClick={deselectAllCategories}
+                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+                >
+                  Изчисти всички
+                </button>
+              </div>
+            </div>
+            <p className="text-sm text-neutral mb-4">
+              Изберете категориите, за които искате да получавате известия. Ако
+              не изберете нищо, ще получавате известия от всички категории.
+            </p>
+            <div className="space-y-1">
+              {CATEGORY_DISPLAY_ORDER.map((category) => (
+                <CategoryFilterItem
+                  key={category}
+                  category={category}
+                  label={CATEGORY_LABELS[category]}
+                  checked={selectedCategories.has(category)}
+                  onChange={() => toggleCategory(category)}
+                />
+              ))}
+              <CategoryFilterItem
+                category={UNCATEGORIZED}
+                label={UNCATEGORIZED_LABEL}
+                checked={selectedCategories.has(UNCATEGORIZED)}
+                onChange={() => toggleCategory(UNCATEGORIZED)}
+              />
+            </div>
+          </section>
+
+          {/* Sources Section */}
+          <section className="bg-white rounded-lg shadow mb-6 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-foreground">
+                Източници
+              </h2>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => selectAllSources(allSourceIds)}
+                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+                >
+                  Избери всички
+                </button>
+                <span className="text-neutral-border">|</span>
+                <button
+                  type="button"
+                  onClick={deselectAllSources}
+                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+                >
+                  Изчисти всички
+                </button>
+              </div>
+            </div>
+            <p className="text-sm text-neutral mb-4">
+              Изберете източниците, от които искате да получавате известия. Ако
+              не изберете нищо, ще получавате известия от всички източници.
+            </p>
+            <div className="space-y-1">
+              {sources.map((source) => (
+                <SourceFilterItem
+                  key={source.id}
+                  label={source.name}
+                  checked={selectedSources.has(source.id)}
+                  onChange={() => toggleSource(source.id)}
+                  count={0}
+                  isLoadingCount={false}
+                />
+              ))}
+            </div>
+          </section>
+
+          {/* Actions */}
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving || !isDirty}
+              className={`${buttonStyles.primary} ${buttonSizes.md} ${borderRadius.sm}`}
+            >
+              {isSaving ? "Запазване..." : "Запази"}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={isSaving}
+              className={`${buttonStyles.ghost} ${buttonSizes.md} ${borderRadius.sm}`}
+            >
+              Отказ
+            </button>
+            <button
+              type="button"
+              onClick={clearAll}
+              disabled={
+                isSaving ||
+                (selectedCategories.size === 0 && selectedSources.size === 0)
+              }
+              className={`${buttonStyles.secondary} ${buttonSizes.md} ${borderRadius.sm} ml-auto`}
+            >
+              Изчисти всички филтри
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/app/settings/notification-filters/page.tsx
+++ b/web/app/settings/notification-filters/page.tsx
@@ -6,6 +6,7 @@ import { useNotificationFilters } from "@/lib/hooks/useNotificationFilters";
 import { getCurrentLocalitySources } from "@/lib/source-utils";
 import CategoryFilterItem from "@/components/CategoryFilterItem";
 import SourceFilterItem from "@/components/SourceFilterItem";
+import FilterSection from "@/components/FilterSection";
 import {
   CATEGORY_DISPLAY_ORDER,
   CATEGORY_LABELS,
@@ -14,10 +15,10 @@ import {
 } from "@oboapp/shared";
 import { buttonStyles, buttonSizes } from "@/lib/theme";
 import { borderRadius } from "@/lib/colors";
-import { ArrowLeft, Info } from "lucide-react";
-import Link from "next/link";
-import { useEffect, useMemo } from "react";
+import { Info } from "lucide-react";
+import BackButton from "@/components/BackButton";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { useEffect, useMemo } from "react";
 
 export default function NotificationFiltersPage() {
   const router = useRouter();
@@ -65,11 +66,9 @@ export default function NotificationFiltersPage() {
   }, [authLoading, user, router]);
 
   const handleSave = async () => {
-    try {
-      await save();
+    const success = await save();
+    if (success) {
       router.push("/settings");
-    } catch {
-      // Error is shown via the hook's error state
     }
   };
 
@@ -80,170 +79,123 @@ export default function NotificationFiltersPage() {
 
   if (authLoading || !user) {
     return (
-      <div className="flex justify-center items-center min-h-screen">
-        <LoadingSpinner />
+      <div className="min-h-screen bg-gray-50 flex justify-center items-center">
+        <LoadingSpinner size="lg" />
       </div>
     );
   }
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-6">
-      {/* Header */}
-      <div className="flex items-center gap-3 mb-6">
-        <Link
-          href="/settings"
-          className="text-neutral hover:text-foreground transition-colors"
-          aria-label="Обратно към настройки"
-        >
-          <ArrowLeft size={24} />
-        </Link>
-        <h1 className="text-2xl font-bold text-foreground">
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Back button */}
+        <div className="mb-6">
+          <BackButton />
+        </div>
+
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">
           Филтри за известия
         </h1>
-      </div>
 
-      {/* Info banner */}
-      <div className="flex items-start gap-3 p-4 mb-6 bg-info-light border border-info-border rounded-lg">
-        <Info size={20} className="text-info flex-shrink-0 mt-0.5" />
-        <p className="text-sm text-info">
-          Промените ще се приложат само за бъдещи известия. Вече получените
-          известия няма да бъдат засегнати.
-        </p>
-      </div>
-
-      {error && (
-        <div className="p-4 mb-6 bg-error-light border border-error-border rounded-lg text-error text-sm">
-          {error}
+        {/* Info banner */}
+        <div className="flex items-start gap-3 p-4 mb-6 bg-info-light border border-info-border rounded-lg">
+          <Info size={20} className="text-info flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-info">
+            Промените ще се приложат само за бъдещи известия. Вече получените
+            известия няма да бъдат засегнати.
+          </p>
         </div>
-      )}
 
-      {isLoading ? (
-        <div className="flex justify-center items-center py-12">
-          <LoadingSpinner />
-        </div>
-      ) : (
-        <>
-          {/* Categories Section */}
-          <section className="bg-white rounded-lg shadow mb-6 p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-foreground">
-                Категории
-              </h2>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => selectAllCategories(allCategoryValues)}
-                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
-                >
-                  Избери всички
-                </button>
-                <span className="text-neutral-border">|</span>
-                <button
-                  type="button"
-                  onClick={deselectAllCategories}
-                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
-                >
-                  Изчисти всички
-                </button>
-              </div>
-            </div>
-            <p className="text-sm text-neutral mb-4">
-              Изберете категориите, за които искате да получавате известия. Ако
-              не изберете нищо, ще получавате известия от всички категории.
-            </p>
-            <div className="space-y-1">
-              {CATEGORY_DISPLAY_ORDER.map((category) => (
-                <CategoryFilterItem
-                  key={category}
-                  category={category}
-                  label={CATEGORY_LABELS[category]}
-                  checked={selectedCategories.has(category)}
-                  onChange={() => toggleCategory(category)}
-                />
-              ))}
-              <CategoryFilterItem
-                category={UNCATEGORIZED}
-                label={UNCATEGORIZED_LABEL}
-                checked={selectedCategories.has(UNCATEGORIZED)}
-                onChange={() => toggleCategory(UNCATEGORIZED)}
-              />
-            </div>
-          </section>
-
-          {/* Sources Section */}
-          <section className="bg-white rounded-lg shadow mb-6 p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-foreground">
-                Източници
-              </h2>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => selectAllSources(allSourceIds)}
-                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
-                >
-                  Избери всички
-                </button>
-                <span className="text-neutral-border">|</span>
-                <button
-                  type="button"
-                  onClick={deselectAllSources}
-                  className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
-                >
-                  Изчисти всички
-                </button>
-              </div>
-            </div>
-            <p className="text-sm text-neutral mb-4">
-              Изберете източниците, от които искате да получавате известия. Ако
-              не изберете нищо, ще получавате известия от всички източници.
-            </p>
-            <div className="space-y-1">
-              {sources.map((source) => (
-                <SourceFilterItem
-                  key={source.id}
-                  label={source.name}
-                  checked={selectedSources.has(source.id)}
-                  onChange={() => toggleSource(source.id)}
-                  count={0}
-                  isLoadingCount={false}
-                />
-              ))}
-            </div>
-          </section>
-
-          {/* Actions */}
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={isSaving || !isDirty}
-              className={`${buttonStyles.primary} ${buttonSizes.md} ${borderRadius.sm}`}
-            >
-              {isSaving ? "Запазване..." : "Запази"}
-            </button>
-            <button
-              type="button"
-              onClick={handleCancel}
-              disabled={isSaving}
-              className={`${buttonStyles.ghost} ${buttonSizes.md} ${borderRadius.sm}`}
-            >
-              Отказ
-            </button>
-            <button
-              type="button"
-              onClick={clearAll}
-              disabled={
-                isSaving ||
-                (selectedCategories.size === 0 && selectedSources.size === 0)
-              }
-              className={`${buttonStyles.secondary} ${buttonSizes.md} ${borderRadius.sm} ml-auto`}
-            >
-              Изчисти всички филтри
-            </button>
+        {error && (
+          <div className="p-4 mb-6 bg-error-light border border-error-border rounded-lg text-error text-sm">
+            {error}
           </div>
-        </>
-      )}
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center items-center py-12">
+            <LoadingSpinner />
+          </div>
+        ) : (
+          <>
+            {/* Filter sections */}
+            <div className="bg-white rounded-lg shadow mb-6">
+              <FilterSection
+                title="Категории"
+                description="Изберете категориите, за които искате да получавате известия. Ако не изберете нищо, ще получавате известия от всички категории."
+                hasActiveFilters={selectedCategories.size > 0}
+                onSelectAll={() => selectAllCategories(allCategoryValues)}
+                onDeselectAll={deselectAllCategories}
+              >
+                {CATEGORY_DISPLAY_ORDER.map((category) => (
+                  <CategoryFilterItem
+                    key={category}
+                    category={category}
+                    label={CATEGORY_LABELS[category]}
+                    checked={selectedCategories.has(category)}
+                    onChange={() => toggleCategory(category)}
+                  />
+                ))}
+                <CategoryFilterItem
+                  category={UNCATEGORIZED}
+                  label={UNCATEGORIZED_LABEL}
+                  checked={selectedCategories.has(UNCATEGORIZED)}
+                  onChange={() => toggleCategory(UNCATEGORIZED)}
+                />
+              </FilterSection>
+
+              <FilterSection
+                title="Източници"
+                description="Изберете източниците, от които искате да получавате известия. Ако не изберете нищо, ще получавате известия от всички източници."
+                hasActiveFilters={selectedSources.size > 0}
+                onSelectAll={() => selectAllSources(allSourceIds)}
+                onDeselectAll={deselectAllSources}
+              >
+                {sources.map((source) => (
+                  <SourceFilterItem
+                    key={source.id}
+                    label={source.name}
+                    checked={selectedSources.has(source.id)}
+                    onChange={() => toggleSource(source.id)}
+                  />
+                ))}
+              </FilterSection>
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving || !isDirty}
+                className={`${buttonStyles.primary} ${buttonSizes.md} ${borderRadius.sm}`}
+              >
+                {isSaving ? "Запазване..." : "Запази"}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={isSaving}
+                className={`${buttonStyles.ghost} ${buttonSizes.md} ${borderRadius.sm}`}
+              >
+                Отказ
+              </button>
+              <button
+                type="button"
+                onClick={clearAll}
+                disabled={
+                  isSaving ||
+                  (selectedCategories.size === 0 && selectedSources.size === 0)
+                }
+                className={`${buttonStyles.secondary} ${buttonSizes.md} ${borderRadius.sm} ml-auto`}
+              >
+                Изчисти всички филтри
+              </button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }
+

--- a/web/components/BackButton.tsx
+++ b/web/components/BackButton.tsx
@@ -1,26 +1,49 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 /**
- * Reusable back navigation button with consistent styling.
- * Uses router.back() to navigate to previous page in browser history.
+ * Reusable back navigation button/link with consistent styling.
+ * When `href` is provided, renders a Link to that URL.
+ * Otherwise, uses router.back() to navigate to the previous page in browser history.
  */
 interface BackButtonProps {
   readonly label?: string;
+  readonly href?: string;
 }
 
-export default function BackButton({ label = "Назад" }: BackButtonProps) {
+const BACK_BUTTON_CLASS =
+  "text-primary hover:text-primary-hover inline-flex items-center gap-2 transition-colors cursor-pointer";
+
+export default function BackButton({
+  label = "Назад",
+  href,
+}: BackButtonProps) {
   const router = useRouter();
+
+  const content = (
+    <>
+      <span>←</span>
+      <span>{label}</span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={BACK_BUTTON_CLASS}>
+        {content}
+      </Link>
+    );
+  }
 
   return (
     <button
       type="button"
       onClick={() => router.back()}
-      className="text-primary hover:text-primary-hover hover:underline inline-flex items-center gap-2 transition-colors cursor-pointer"
+      className={BACK_BUTTON_CLASS}
     >
-      <span>←</span>
-      <span>{label}</span>
+      {content}
     </button>
   );
 }

--- a/web/components/FilterSection.tsx
+++ b/web/components/FilterSection.tsx
@@ -2,11 +2,14 @@
 
 import { ReactNode } from "react";
 import Accordion from "@/components/Accordion";
+import { buttonStyles, buttonSizes } from "@/lib/theme";
+import { borderRadius } from "@/lib/colors";
 
 interface FilterSectionProps {
   readonly title: string;
   readonly description: string;
   readonly hasActiveFilters: boolean;
+  readonly allSelected: boolean;
   readonly onSelectAll: () => void;
   readonly onDeselectAll: () => void;
   readonly children: ReactNode;
@@ -20,10 +23,12 @@ export default function FilterSection({
   title,
   description,
   hasActiveFilters,
+  allSelected,
   onSelectAll,
   onDeselectAll,
   children,
 }: FilterSectionProps) {
+  const actionButtonClasses = `text-xs ${buttonStyles.ghost} ${buttonSizes.sm} ${borderRadius.sm}`;
   return (
     <Accordion title={title} hasActiveFilters={hasActiveFilters}>
       <div className="px-4 pt-2 pb-4">
@@ -31,15 +36,16 @@ export default function FilterSection({
           <button
             type="button"
             onClick={onSelectAll}
-            className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+            disabled={allSelected}
+            className={actionButtonClasses}
           >
             Избери всички
           </button>
-          <span className="text-neutral-border">|</span>
           <button
             type="button"
             onClick={onDeselectAll}
-            className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+            disabled={!hasActiveFilters}
+            className={actionButtonClasses}
           >
             Изчисти всички
           </button>

--- a/web/components/FilterSection.tsx
+++ b/web/components/FilterSection.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactNode } from "react";
+import Accordion from "@/components/Accordion";
+
+interface FilterSectionProps {
+  readonly title: string;
+  readonly description: string;
+  readonly hasActiveFilters: boolean;
+  readonly onSelectAll: () => void;
+  readonly onDeselectAll: () => void;
+  readonly children: ReactNode;
+}
+
+/**
+ * Reusable filter section with accordion toggle, description, and select/deselect all controls.
+ * Shows a red dot indicator on the accordion header when closed and has active filters.
+ */
+export default function FilterSection({
+  title,
+  description,
+  hasActiveFilters,
+  onSelectAll,
+  onDeselectAll,
+  children,
+}: FilterSectionProps) {
+  return (
+    <Accordion title={title} hasActiveFilters={hasActiveFilters}>
+      <div className="px-4 pt-2 pb-4">
+        <div className="flex items-center gap-2 mb-2">
+          <button
+            type="button"
+            onClick={onSelectAll}
+            className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+          >
+            Избери всички
+          </button>
+          <span className="text-neutral-border">|</span>
+          <button
+            type="button"
+            onClick={onDeselectAll}
+            className="text-xs text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+          >
+            Изчисти всички
+          </button>
+        </div>
+        <p className="text-sm text-neutral mb-3">{description}</p>
+        <div className="space-y-1">{children}</div>
+      </div>
+    </Accordion>
+  );
+}

--- a/web/components/LoadingSpinner.tsx
+++ b/web/components/LoadingSpinner.tsx
@@ -1,0 +1,19 @@
+interface LoadingSpinnerProps {
+  readonly size?: "sm" | "md" | "lg";
+}
+
+const sizeClasses = {
+  sm: "h-5 w-5",
+  md: "h-8 w-8",
+  lg: "h-12 w-12",
+};
+
+export default function LoadingSpinner({ size = "md" }: LoadingSpinnerProps) {
+  return (
+    <div
+      className={`animate-spin rounded-full border-b-2 border-primary ${sizeClasses[size]}`}
+      role="status"
+      aria-label="Зарежда се"
+    />
+  );
+}

--- a/web/components/LoadingSpinner.tsx
+++ b/web/components/LoadingSpinner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 interface LoadingSpinnerProps {
   readonly size?: "sm" | "md" | "lg";
 }

--- a/web/components/NotificationDropdown.tsx
+++ b/web/components/NotificationDropdown.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/notification-service";
 import { formatNotificationDateTime } from "@/lib/notification-history";
 import { useNotificationHistory } from "@/lib/hooks/useNotificationHistory";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 interface NotificationDropdownProps {
   readonly isOpen: boolean;
@@ -134,7 +135,7 @@ export default function NotificationDropdown({
 
         {isLoading ? (
           <div className="flex justify-center items-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            <LoadingSpinner />
           </div>
         ) : error ? (
           <div className="p-4 text-center text-error">{error}</div>

--- a/web/components/NotificationDropdown.tsx
+++ b/web/components/NotificationDropdown.tsx
@@ -98,15 +98,25 @@ export default function NotificationDropdown({
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-neutral-border">
         <h3 className="text-lg font-semibold text-foreground">Известия</h3>
-        {notifications.length > 0 && (
-          <button
-            type="button"
-            onClick={markAllRead}
-            className="text-sm text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+        <div className="flex items-center gap-3">
+          <Link
+            href="/settings/notification-filters"
+            onClick={onClose}
+            className="text-sm text-primary hover:text-primary-hover hover:underline transition-colors"
+            title="Филтри за известия"
           >
-            Маркирай всички прочетени
-          </button>
-        )}
+            Филтри
+          </Link>
+          {notifications.length > 0 && (
+            <button
+              type="button"
+              onClick={markAllRead}
+              className="text-sm text-primary hover:text-primary-hover hover:underline cursor-pointer transition-colors"
+            >
+              Маркирай всички прочетени
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Content */}

--- a/web/components/SourceFilterItem.tsx
+++ b/web/components/SourceFilterItem.tsx
@@ -6,8 +6,8 @@ interface SourceFilterItemProps {
   readonly label: string;
   readonly checked: boolean;
   readonly onChange: () => void;
-  readonly count: number;
-  readonly isLoadingCount: boolean;
+  readonly count?: number;
+  readonly isLoadingCount?: boolean;
 }
 
 /**
@@ -19,7 +19,7 @@ export default function SourceFilterItem({
   checked,
   onChange,
   count,
-  isLoadingCount,
+  isLoadingCount = false,
 }: SourceFilterItemProps) {
   return (
     <button

--- a/web/lib/hooks/useNotificationFilters.ts
+++ b/web/lib/hooks/useNotificationFilters.ts
@@ -30,7 +30,13 @@ export function useNotificationFilters() {
 
   // Fetch current filters on mount
   useEffect(() => {
-    if (!user) return;
+    if (!user) {
+      setIsLoading(false);
+      setSavedFilters(EMPTY_FILTERS);
+      setSelectedCategories(new Set());
+      setSelectedSources(new Set());
+      return;
+    }
 
     let cancelled = false;
     const currentUser = user;
@@ -122,8 +128,8 @@ export function useNotificationFilters() {
     return false;
   }, [savedFilters, selectedCategories, selectedSources]);
 
-  const save = useCallback(async () => {
-    if (!user) return;
+  const save = useCallback(async (): Promise<boolean> => {
+    if (!user) return false;
 
     try {
       setIsSaving(true);
@@ -146,10 +152,11 @@ export function useNotificationFilters() {
       setSavedFilters(data);
       setSelectedCategories(new Set(data.notificationCategories));
       setSelectedSources(new Set(data.notificationSources));
+      return true;
     } catch (err) {
       console.error("Error saving notification filters:", err);
       setError("Грешка при запазване на филтрите");
-      throw err;
+      return false;
     } finally {
       setIsSaving(false);
     }

--- a/web/lib/hooks/useNotificationFilters.ts
+++ b/web/lib/hooks/useNotificationFilters.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useAuth } from "@/lib/auth-context";
+import { fetchWithAuth } from "@/lib/auth-fetch";
+
+interface NotificationFiltersState {
+  notificationCategories: string[];
+  notificationSources: string[];
+}
+
+const EMPTY_FILTERS: NotificationFiltersState = {
+  notificationCategories: [],
+  notificationSources: [],
+};
+
+export function useNotificationFilters() {
+  const { user } = useAuth();
+  const [savedFilters, setSavedFilters] =
+    useState<NotificationFiltersState>(EMPTY_FILTERS);
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
+    new Set(),
+  );
+  const [selectedSources, setSelectedSources] = useState<Set<string>>(
+    new Set(),
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch current filters on mount
+  useEffect(() => {
+    if (!user) return;
+
+    let cancelled = false;
+    const currentUser = user;
+
+    async function fetchFilters() {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const res = await fetchWithAuth(
+          currentUser,
+          "/api/notifications/filters",
+        );
+        if (!res.ok) throw new Error("Failed to fetch filters");
+        const data: NotificationFiltersState = await res.json();
+        if (cancelled) return;
+        setSavedFilters(data);
+        setSelectedCategories(new Set(data.notificationCategories));
+        setSelectedSources(new Set(data.notificationSources));
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Error fetching notification filters:", err);
+        setError("Грешка при зареждане на филтрите");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void fetchFilters();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const toggleCategory = useCallback((category: string) => {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSource = useCallback((source: string) => {
+    setSelectedSources((prev) => {
+      const next = new Set(prev);
+      if (next.has(source)) {
+        next.delete(source);
+      } else {
+        next.add(source);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAllCategories = useCallback((allCategories: string[]) => {
+    setSelectedCategories(new Set(allCategories));
+  }, []);
+
+  const deselectAllCategories = useCallback(() => {
+    setSelectedCategories(new Set());
+  }, []);
+
+  const selectAllSources = useCallback((allSources: string[]) => {
+    setSelectedSources(new Set(allSources));
+  }, []);
+
+  const deselectAllSources = useCallback(() => {
+    setSelectedSources(new Set());
+  }, []);
+
+  const isDirty = useMemo(() => {
+    const savedCats = new Set(savedFilters.notificationCategories);
+    const savedSrcs = new Set(savedFilters.notificationSources);
+
+    if (selectedCategories.size !== savedCats.size) return true;
+    if (selectedSources.size !== savedSrcs.size) return true;
+
+    for (const cat of selectedCategories) {
+      if (!savedCats.has(cat)) return true;
+    }
+    for (const src of selectedSources) {
+      if (!savedSrcs.has(src)) return true;
+    }
+
+    return false;
+  }, [savedFilters, selectedCategories, selectedSources]);
+
+  const save = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      setIsSaving(true);
+      setError(null);
+
+      const body = {
+        notificationCategories: [...selectedCategories],
+        notificationSources: [...selectedSources],
+      };
+
+      const res = await fetchWithAuth(user, "/api/notifications/filters", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) throw new Error("Failed to save filters");
+
+      const data: NotificationFiltersState = await res.json();
+      setSavedFilters(data);
+      setSelectedCategories(new Set(data.notificationCategories));
+      setSelectedSources(new Set(data.notificationSources));
+    } catch (err) {
+      console.error("Error saving notification filters:", err);
+      setError("Грешка при запазване на филтрите");
+      throw err;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [user, selectedCategories, selectedSources]);
+
+  const clearAll = useCallback(() => {
+    setSelectedCategories(new Set());
+    setSelectedSources(new Set());
+  }, []);
+
+  const resetToSaved = useCallback(() => {
+    setSelectedCategories(new Set(savedFilters.notificationCategories));
+    setSelectedSources(new Set(savedFilters.notificationSources));
+  }, [savedFilters]);
+
+  return {
+    selectedCategories,
+    selectedSources,
+    isLoading,
+    isSaving,
+    error,
+    isDirty,
+    toggleCategory,
+    toggleSource,
+    selectAllCategories,
+    deselectAllCategories,
+    selectAllSources,
+    deselectAllSources,
+    save,
+    clearAll,
+    resetToSaved,
+  };
+}


### PR DESCRIPTION
Allow users to filter which notifications they receive by category and/or source. Inclusion-based semantics: empty filters = receive all.

- Add UserPreferences schema (shared) and DB repository (db)
- Add GET/PUT/DELETE /api/notifications/filters endpoints (web)
- Integrate filter logic into match-processor at notification time (ingest)
- Add /settings/notification-filters page with category & source toggles
- Add entry points in NotificationDropdown and Settings page
- Add MSW mock handlers for dev mode
- Add 14 unit tests for shouldNotifyUser()
- Add E2E Gherkin specification (19 scenarios)

<img width="2904" height="4724" alt="screencapture-oborishte-map-git-feat-notifi-824bd4-valery-buchinskys-projects-vercel-app-settings-notification-filters-2026-03-10-10_45_37" src="https://github.com/user-attachments/assets/046e1e2b-292b-4d4e-b6a4-2cd3e726beb8" />
