### PR TITLE
feat: add event aggregation feature with API endpoints and UI components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,7 +398,7 @@ The UI is in Bulgarian. All Bulgarian text must use consistent register:
 
 **Architecture**:
 
-- **Fixtures**: Static mock data in `web/__mocks__/fixtures/` (~20 messages, 2 interests, 5 notifications)
+- **Fixtures**: Static mock data in `web/__mocks__/fixtures/` (~20 messages, 7 events, 2 interests, 5 notifications)
 - **Handlers**: MSW request handlers in `web/__mocks__/handlers.ts` intercept all `/api/*` routes
 - **Browser worker**: `web/__mocks__/browser.ts` sets up service worker in development mode
 - **Auth mock**: `web/__mocks__/firebase-auth.ts` provides pre-authenticated user state
@@ -407,7 +407,7 @@ The UI is in Bulgarian. All Bulgarian text must use consistent register:
 
 **Coverage**:
 
-- ✅ All API routes mocked (messages, interests, subscriptions, notifications)
+- ✅ All API routes mocked (messages, events, interests, subscriptions, notifications)
 - ✅ Firebase Auth returns mock user (bypasses Google OAuth)
 - ✅ In-memory CRUD state for interests/subscriptions
 - ❌ No Firebase Cloud Messaging (push notifications)

--- a/docs/features/event-aggregation.md
+++ b/docs/features/event-aggregation.md
@@ -78,6 +78,20 @@ npx tsx migrate/2026-03-15-create-events-from-messages.ts
 
 The migration is idempotent — running it again skips already-linked messages.
 
+## Web Observability Page
+
+The `/events` page provides a read-only view of all events for observability before events replace messages on the map.
+
+- **Single-message events** (1:1) render as flat cards
+- **Multi-message events** render as collapsed accordions — expanding shows linked messages with their confidence scores and source names
+- Pagination loads older events on demand
+- Accessible via the footer link "Групирани съобщения"
+
+API endpoints:
+
+- `GET /api/events` — paginated event list (cursor-based, sorted by `updatedAt` desc, filtered by locality)
+- `GET /api/events/messages?eventId=X` — messages linked to a specific event with `EventMessage` match metadata
+
 ## Related
 
 - [database-layer.md](database-layer.md) — DB access patterns for `events` and `eventMessages` collections, and the linking model (`eventMessages` as authoritative source of truth vs `messages.eventId` as denormalized cache)

--- a/docs/setup/quick-start-frontend-msw.md
+++ b/docs/setup/quick-start-frontend-msw.md
@@ -54,6 +54,7 @@ You should see console logs indicating MSW is active:
 ✅ **Fully Functional**:
 
 - Map display with ~20 pre-generated messages
+- Grouped events page (`/events`) with event accordions
 - Category filtering
 - Viewport-based message filtering
 - Interest zone management (create, edit, delete)
@@ -81,6 +82,12 @@ You should see console logs indicating MSW is active:
 - **~20 messages** covering all categories (water, construction, public-transport, etc.)
 - **Mixed locations**: Some clustered around city center, others scattered across Sofia
 - **Edge cases**: City-wide alerts, messages without GeoJSON, long text, uncategorized messages
+
+### Events
+
+- **7 events** grouping messages into real-world incidents
+- **Mix of single-message events** (1:1) and **multi-message events** (2–3 messages each)
+- **Event-message links** with confidence scores and match signals
 
 ### User State
 

--- a/ingest/firestore.indexes.json
+++ b/ingest/firestore.indexes.json
@@ -121,10 +121,26 @@
       ]
     },
     {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "locality", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "eventMessages",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "eventId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "interests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     }

--- a/web/__mocks__/fixtures/events.ts
+++ b/web/__mocks__/fixtures/events.ts
@@ -1,0 +1,381 @@
+import type { Event, EventMessage } from "@oboapp/shared";
+
+/**
+ * Static fixtures for events
+ * Groups mock messages into realistic event aggregations
+ */
+export const MOCK_EVENTS: Event[] = [
+  // Event 1: Water outage — single message (1:1 event)
+  {
+    id: "evt-water-center-1",
+    plainText:
+      "Планирано спиране на водоподаването на ул. Граф Игнатиев от No 5 до No 25",
+    markdownText:
+      "**Планирано спиране** на водоподаването на **ул. Граф Игнатиев** от No 5 до No 25",
+    categories: ["water"],
+    sources: ["sofiyska-voda"],
+    messageCount: 1,
+    confidence: 1,
+    geometryQuality: 3,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-10T09:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-10T17:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T08:05:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T08:05:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [23.3205, 42.6965],
+              [23.3225, 42.6975],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+
+  // Event 2: Construction work — 3 messages from different sources
+  {
+    id: "evt-construction-center",
+    plainText:
+      "Строително-ремонтни дейности в централна градска част до Народно събрание",
+    categories: ["construction-and-repairs", "road-block"],
+    sources: ["sofia-bg", "rayon-oborishte-bg"],
+    messageCount: 3,
+    confidence: 0.85,
+    geometryQuality: 2,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-10T07:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-15T18:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T09:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T15:30:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [23.335, 42.694],
+                [23.345, 42.694],
+                [23.345, 42.699],
+                [23.335, 42.699],
+                [23.335, 42.694],
+              ],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+
+  // Event 3: Public transport change — 2 messages
+  {
+    id: "evt-transport-center",
+    plainText:
+      "Промяна на маршрута на трамвай №5 поради ремонт на релсов път",
+    categories: ["public-transport", "traffic"],
+    sources: ["sofia-bg"],
+    messageCount: 2,
+    confidence: 0.78,
+    geometryQuality: 2,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-10T05:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-20T23:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T10:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T14:00:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [23.322, 42.697],
+              [23.328, 42.7],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+
+  // Event 4: Heating outage — single message
+  {
+    id: "evt-heating-mladost",
+    plainText: "Аварийно спиране на топлоподаването в ж.к. Младост 1А",
+    categories: ["heating"],
+    sources: ["toplo-bg"],
+    messageCount: 1,
+    confidence: 1,
+    geometryQuality: 3,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-10T06:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-10T20:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T11:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T11:00:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [23.377, 42.6571],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+
+  // Event 5: Electricity outage — single message
+  {
+    id: "evt-electricity-lozenets",
+    plainText:
+      "Прекъсване на електрозахранването в район Лозенец поради подмяна на трансформатор",
+    categories: ["electricity"],
+    sources: ["erm-zapad"],
+    messageCount: 1,
+    confidence: 1,
+    geometryQuality: 3,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-11T08:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-11T16:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T12:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T12:00:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [23.31, 42.678],
+                [23.33, 42.678],
+                [23.33, 42.688],
+                [23.31, 42.688],
+                [23.31, 42.678],
+              ],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+
+  // Event 6: Weather alert — city-wide, single message
+  {
+    id: "evt-weather-citywide",
+    plainText:
+      "Оранжев код за силен вятър в София — очакват се пориви до 90 км/ч",
+    categories: ["weather"],
+    sources: ["nimh-severe-weather"],
+    messageCount: 1,
+    confidence: 1,
+    geometryQuality: 1,
+    locality: "bg.sofia",
+    cityWide: true,
+    timespanStart: new Date("2026-02-10T00:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-11T00:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T13:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T13:00:00Z").toISOString(),
+    geoJson: { type: "FeatureCollection", features: [] },
+  },
+
+  // Event 7: Traffic + construction — 2 messages from different sources
+  {
+    id: "evt-traffic-ring",
+    plainText:
+      "Ремонт на пътната настилка на Околовръстен път при бул. Цариградско шосе",
+    categories: ["traffic", "construction-and-repairs"],
+    sources: ["sofia-bg"],
+    messageCount: 2,
+    confidence: 0.72,
+    geometryQuality: 2,
+    locality: "bg.sofia",
+    timespanStart: new Date("2026-02-11T07:00:00Z").toISOString(),
+    timespanEnd: new Date("2026-02-17T19:00:00Z").toISOString(),
+    createdAt: new Date("2026-02-09T14:00:00Z").toISOString(),
+    updatedAt: new Date("2026-02-09T16:00:00Z").toISOString(),
+    geoJson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [23.42, 42.665],
+              [23.44, 42.67],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+  },
+];
+
+/**
+ * Event-message links mapping messages to events
+ */
+export const MOCK_EVENT_MESSAGES: EventMessage[] = [
+  // Event 1: Water — 1 message
+  {
+    id: "em-water-1",
+    eventId: "evt-water-center-1",
+    messageId: "msg-water-center-1",
+    source: "sofiyska-voda",
+    confidence: 1,
+    geometryQuality: 3,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T08:05:00Z").toISOString(),
+  },
+
+  // Event 2: Construction — 3 messages
+  {
+    id: "em-construction-1",
+    eventId: "evt-construction-center",
+    messageId: "msg-construction-center-2",
+    source: "sofia-bg",
+    confidence: 1,
+    geometryQuality: 2,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T09:00:00Z").toISOString(),
+  },
+  {
+    id: "em-construction-2",
+    eventId: "evt-construction-center",
+    messageId: "msg-road-block-oborishte-1",
+    source: "rayon-oborishte-bg",
+    confidence: 0.85,
+    geometryQuality: 1,
+    matchSignals: {
+      locationSimilarity: 0.8,
+      timeOverlap: 0.9,
+      categoryMatch: 0.75,
+      textSimilarity: 0.82,
+    },
+    createdAt: new Date("2026-02-09T12:00:00Z").toISOString(),
+  },
+  {
+    id: "em-construction-3",
+    eventId: "evt-construction-center",
+    messageId: "msg-no-geojson-1",
+    source: "sofia-bg",
+    confidence: 0.72,
+    geometryQuality: 0,
+    matchSignals: {
+      locationSimilarity: 0.6,
+      timeOverlap: 0.85,
+      categoryMatch: 1,
+      textSimilarity: 0.7,
+    },
+    createdAt: new Date("2026-02-09T15:30:00Z").toISOString(),
+  },
+
+  // Event 3: Public transport — 2 messages
+  {
+    id: "em-transport-1",
+    eventId: "evt-transport-center",
+    messageId: "msg-public-transport-center-3",
+    source: "sofia-bg",
+    confidence: 1,
+    geometryQuality: 2,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T10:00:00Z").toISOString(),
+  },
+  {
+    id: "em-transport-2",
+    eventId: "evt-transport-center",
+    messageId: "msg-bus-stop-1",
+    source: "sofia-bg",
+    confidence: 0.78,
+    geometryQuality: 1,
+    matchSignals: {
+      locationSimilarity: 0.65,
+      timeOverlap: 0.95,
+      categoryMatch: 1,
+      textSimilarity: 0.68,
+    },
+    createdAt: new Date("2026-02-09T14:00:00Z").toISOString(),
+  },
+
+  // Event 4: Heating — 1 message
+  {
+    id: "em-heating-1",
+    eventId: "evt-heating-mladost",
+    messageId: "msg-heating-mladost-1",
+    source: "toplo-bg",
+    confidence: 1,
+    geometryQuality: 3,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T11:00:00Z").toISOString(),
+  },
+
+  // Event 5: Electricity — 1 message
+  {
+    id: "em-electricity-1",
+    eventId: "evt-electricity-lozenets",
+    messageId: "msg-electricity-lozenets-1",
+    source: "erm-zapad",
+    confidence: 1,
+    geometryQuality: 3,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T12:00:00Z").toISOString(),
+  },
+
+  // Event 6: Weather — 1 message
+  {
+    id: "em-weather-1",
+    eventId: "evt-weather-citywide",
+    messageId: "msg-weather-citywide-1",
+    source: "nimh-severe-weather",
+    confidence: 1,
+    geometryQuality: 1,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T13:00:00Z").toISOString(),
+  },
+
+  // Event 7: Traffic — 2 messages
+  {
+    id: "em-traffic-1",
+    eventId: "evt-traffic-ring",
+    messageId: "msg-traffic-ring-road-1",
+    source: "sofia-bg",
+    confidence: 1,
+    geometryQuality: 2,
+    matchSignals: null,
+    createdAt: new Date("2026-02-09T14:00:00Z").toISOString(),
+  },
+  {
+    id: "em-traffic-2",
+    eventId: "evt-traffic-ring",
+    messageId: "msg-long-text-1",
+    source: "sofia-bg",
+    confidence: 0.72,
+    geometryQuality: 1,
+    matchSignals: {
+      locationSimilarity: 0.7,
+      timeOverlap: 0.8,
+      categoryMatch: 0.5,
+      textSimilarity: 0.65,
+    },
+    createdAt: new Date("2026-02-09T16:00:00Z").toISOString(),
+  },
+];

--- a/web/__mocks__/handlers.ts
+++ b/web/__mocks__/handlers.ts
@@ -5,6 +5,7 @@ import { MOCK_INTERESTS, MOCK_USER_ID } from "./fixtures/interests";
 import { MOCK_SUBSCRIPTIONS } from "./fixtures/subscriptions";
 import { MOCK_NOTIFICATION_HISTORY } from "./fixtures/notification-history";
 import { MOCK_API_CLIENT } from "./fixtures/api-client";
+import { MOCK_EVENTS, MOCK_EVENT_MESSAGES } from "./fixtures/events";
 import { getCentroid } from "@/lib/geometry-utils";
 import type {
   Interest,
@@ -556,5 +557,52 @@ export const handlers = [
       messages: MOCK_UNREADABLE_MESSAGES,
       nextCursor: undefined,
     });
+  }),
+
+  // GET /api/events - Return paginated events sorted by updatedAt desc
+  http.get("/api/events", ({ request }) => {
+    const url = new URL(request.url);
+    const cursorUpdatedAt = url.searchParams.get("cursorUpdatedAt");
+    const cursorId = url.searchParams.get("cursorId");
+
+    let events = [...MOCK_EVENTS].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+
+    if (cursorUpdatedAt && cursorId) {
+      const cursorTime = new Date(cursorUpdatedAt).getTime();
+      events = events.filter((evt) => {
+        const evtTime = new Date(evt.updatedAt).getTime();
+        if (evtTime < cursorTime) return true;
+        if (evtTime > cursorTime) return false;
+        return (evt.id ?? "").localeCompare(cursorId) < 0;
+      });
+    }
+
+    return HttpResponse.json({
+      events,
+      nextCursor: undefined,
+    });
+  }),
+
+  // GET /api/events/messages - Return messages linked to a specific event
+  http.get("/api/events/messages", ({ request }) => {
+    const url = new URL(request.url);
+    const eventId = url.searchParams.get("eventId");
+
+    if (!eventId) {
+      return HttpResponse.json(
+        { error: "eventId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const eventMessages = MOCK_EVENT_MESSAGES.filter(
+      (em) => em.eventId === eventId,
+    );
+    const messageIds = new Set(eventMessages.map((em) => em.messageId));
+    const messages = MOCK_MESSAGES.filter((m) => messageIds.has(m.id ?? ""));
+
+    return HttpResponse.json({ messages, eventMessages });
   }),
 ];

--- a/web/app/api/events/messages/route.ts
+++ b/web/app/api/events/messages/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { recordToMessage } from "@/lib/doc-to-message";
+import { toRequiredISOString } from "@/lib/date-serialization";
+import type { EventMessage } from "@oboapp/shared";
+
+function recordToEventMessage(record: Record<string, unknown>): EventMessage {
+  return {
+    id: record._id as string,
+    eventId: record.eventId as string,
+    messageId: record.messageId as string,
+    source: record.source as string,
+    confidence: (record.confidence as number) ?? 0,
+    geometryQuality: (record.geometryQuality as number) ?? 0,
+    matchSignals: record.matchSignals as EventMessage["matchSignals"],
+    createdAt: toRequiredISOString(record.createdAt, "createdAt"),
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const eventId = searchParams.get("eventId");
+
+    if (!eventId) {
+      return NextResponse.json(
+        { error: "eventId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const db = await getDb();
+
+    // Fetch event-message links
+    const eventMessageDocs = await db.eventMessages.findByEventId(eventId);
+
+    if (eventMessageDocs.length === 0) {
+      return NextResponse.json({ messages: [], eventMessages: [] });
+    }
+
+    // Batch fetch messages
+    const messagePromises = eventMessageDocs.map((em) =>
+      db.messages.findById(em.messageId as string),
+    );
+    const messageRecords = await Promise.all(messagePromises);
+
+    // Filter out nulls (deleted messages) and convert
+    const messages = messageRecords
+      .filter((r): r is Record<string, unknown> => r !== null)
+      .map(recordToMessage);
+
+    const eventMessages = eventMessageDocs.map(recordToEventMessage);
+
+    return NextResponse.json({ messages, eventMessages });
+  } catch (error) {
+    console.error("Error fetching event messages:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch event messages" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/api/events/route.ts
+++ b/web/app/api/events/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import type { WhereClause, OrderByClause } from "@oboapp/db";
+import {
+  toRequiredISOString,
+  toOptionalISOString,
+} from "@/lib/date-serialization";
+import type { Event } from "@oboapp/shared";
+
+const PAGE_SIZE = 20;
+const DEFAULT_RELEVANCE_DAYS = 3;
+
+function getLocality(): string {
+  const locality = process.env.NEXT_PUBLIC_LOCALITY;
+  if (!locality) {
+    throw new Error("NEXT_PUBLIC_LOCALITY environment variable is required");
+  }
+  return locality;
+}
+
+function getCutoffDate(): Date {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - DEFAULT_RELEVANCE_DAYS);
+  return cutoff;
+}
+
+function recordToEvent(record: Record<string, unknown>): Event {
+  return {
+    id: record._id as string,
+    plainText: record.plainText as string,
+    markdownText: record.markdownText as string | undefined,
+    geoJson: record.geoJson as Event["geoJson"],
+    geometryQuality: (record.geometryQuality as number) ?? 0,
+    timespanStart: toOptionalISOString(record.timespanStart, "timespanStart"),
+    timespanEnd: toOptionalISOString(record.timespanEnd, "timespanEnd"),
+    categories: Array.isArray(record.categories) ? record.categories : [],
+    pins: Array.isArray(record.pins) ? record.pins : undefined,
+    streets: Array.isArray(record.streets) ? record.streets : undefined,
+    cadastralProperties: Array.isArray(record.cadastralProperties)
+      ? record.cadastralProperties
+      : undefined,
+    busStops: Array.isArray(record.busStops) ? record.busStops : undefined,
+    sources: Array.isArray(record.sources) ? record.sources : [],
+    messageCount: (record.messageCount as number) ?? 1,
+    confidence: (record.confidence as number) ?? 0,
+    locality: (record.locality as string) ?? "",
+    cityWide: (record.cityWide as boolean) || false,
+    createdAt: toRequiredISOString(record.createdAt, "createdAt"),
+    updatedAt: toRequiredISOString(record.updatedAt, "updatedAt"),
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const cursorUpdatedAt = searchParams.get("cursorUpdatedAt");
+    const cursorId = searchParams.get("cursorId");
+
+    if (
+      (cursorUpdatedAt && !cursorId) ||
+      (!cursorUpdatedAt && cursorId)
+    ) {
+      return NextResponse.json(
+        { error: "Both cursorUpdatedAt and cursorId must be provided together" },
+        { status: 400 },
+      );
+    }
+
+    const db = await getDb();
+    const locality = getLocality();
+    const cutoffDate = getCutoffDate();
+
+    const where: WhereClause[] = [
+      { field: "locality", op: "==", value: locality },
+      { field: "updatedAt", op: ">=", value: cutoffDate.toISOString() },
+    ];
+
+    if (cursorUpdatedAt) {
+      const parsed = new Date(cursorUpdatedAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json(
+          { error: "Invalid cursorUpdatedAt parameter" },
+          { status: 400 },
+        );
+      }
+    }
+
+    const orderBy: OrderByClause[] = [
+      { field: "updatedAt", direction: "desc" },
+    ];
+
+    const fetchedDocs = await db.events.findMany({
+      where,
+      orderBy,
+      limit: PAGE_SIZE + 1,
+    });
+
+    // Apply cursor filtering in memory (Firestore supports one range filter)
+    let filtered = fetchedDocs;
+    if (cursorUpdatedAt && cursorId) {
+      const cursorTime = new Date(cursorUpdatedAt).getTime();
+      filtered = fetchedDocs.filter((doc) => {
+        const docTime = new Date(doc.updatedAt as string).getTime();
+        if (docTime < cursorTime) return true;
+        if (docTime > cursorTime) return false;
+        return String(doc._id).localeCompare(cursorId) < 0;
+      });
+    }
+
+    const hasMore = filtered.length > PAGE_SIZE;
+    const pageDocs = filtered.slice(0, PAGE_SIZE);
+    const events = pageDocs.map(recordToEvent);
+
+    const lastDoc = pageDocs[pageDocs.length - 1];
+    const nextCursor =
+      hasMore && lastDoc
+        ? {
+            updatedAt: toRequiredISOString(lastDoc.updatedAt, "updatedAt"),
+            id: String(lastDoc._id),
+          }
+        : undefined;
+
+    return NextResponse.json({ events, nextCursor });
+  } catch (error) {
+    console.error("Error fetching events:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch events" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/api/events/route.ts
+++ b/web/app/api/events/route.ts
@@ -5,18 +5,11 @@ import {
   toRequiredISOString,
   toOptionalISOString,
 } from "@/lib/date-serialization";
+import { getLocality } from "@/lib/bounds-utils";
 import type { Event } from "@oboapp/shared";
 
 const PAGE_SIZE = 20;
 const DEFAULT_RELEVANCE_DAYS = 3;
-
-function getLocality(): string {
-  const locality = process.env.NEXT_PUBLIC_LOCALITY;
-  if (!locality) {
-    throw new Error("NEXT_PUBLIC_LOCALITY environment variable is required");
-  }
-  return locality;
-}
 
 function getCutoffDate(): Date {
   const cutoff = new Date();
@@ -56,12 +49,11 @@ export async function GET(request: Request) {
     const cursorUpdatedAt = searchParams.get("cursorUpdatedAt");
     const cursorId = searchParams.get("cursorId");
 
-    if (
-      (cursorUpdatedAt && !cursorId) ||
-      (!cursorUpdatedAt && cursorId)
-    ) {
+    if ((cursorUpdatedAt && !cursorId) || (!cursorUpdatedAt && cursorId)) {
       return NextResponse.json(
-        { error: "Both cursorUpdatedAt and cursorId must be provided together" },
+        {
+          error: "Both cursorUpdatedAt and cursorId must be provided together",
+        },
         { status: 400 },
       );
     }

--- a/web/app/events/page.tsx
+++ b/web/app/events/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import Image from "next/image";
+import { useState } from "react";
+import type { Event } from "@oboapp/shared";
+import sources from "@/lib/sources.json";
+import { stripMarkdown } from "@/lib/markdown-utils";
+import { getButtonClasses } from "@/lib/theme";
+import CategoryChips from "@/components/CategoryChips";
+import EventAccordion from "@/components/EventAccordion";
+
+type EventsCursor = {
+  updatedAt: string;
+  id: string;
+};
+
+type EventsResponse = {
+  events: Event[];
+  nextCursor?: EventsCursor;
+};
+
+const fetchEvents = async ({
+  pageParam,
+  signal,
+}: {
+  pageParam?: EventsCursor;
+  signal?: AbortSignal;
+}): Promise<EventsResponse> => {
+  const params = new URLSearchParams();
+  if (pageParam) {
+    params.set("cursorUpdatedAt", pageParam.updatedAt);
+    params.set("cursorId", pageParam.id);
+  }
+
+  const response = await fetch(`/api/events?${params}`, { signal });
+  if (!response.ok) throw new Error("Failed to fetch events");
+  return response.json();
+};
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  const day = date.getDate().toString().padStart(2, "0");
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const year = date.getFullYear();
+  return `${day}.${month}.${year}`;
+}
+
+function formatTimespan(
+  start: string | undefined,
+  end: string | undefined,
+): string {
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+  if (startStr && endStr && startStr !== endStr) return `${startStr} – ${endStr}`;
+  if (startStr) return startStr;
+  if (endStr) return endStr;
+  return "";
+}
+
+function SourceLogo({ sourceId }: { readonly sourceId: string }) {
+  const [error, setError] = useState(false);
+  const sourceInfo = sources.find((s) => s.id === sourceId);
+  const logoPath = `/sources/${sourceId}.png`;
+
+  if (error) {
+    return (
+      <span className="text-xs text-neutral truncate">
+        {sourceInfo?.name || sourceId}
+      </span>
+    );
+  }
+
+  return (
+    <Image
+      src={logoPath}
+      alt={sourceInfo?.name || sourceId}
+      width={24}
+      height={24}
+      className="w-6 h-6 object-contain flex-shrink-0"
+      onError={() => setError(true)}
+    />
+  );
+}
+
+function SingleEventCard({ event }: { readonly event: Event }) {
+  const displayText = event.markdownText || event.plainText;
+  const clean = stripMarkdown(displayText);
+  const snippet =
+    clean.length > 150
+      ? clean.substring(0, clean.lastIndexOf(" ", 150) > 120 ? clean.lastIndexOf(" ", 150) : 150) + "..."
+      : clean;
+  const timespan = formatTimespan(event.timespanStart, event.timespanEnd);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 border border-neutral-border">
+      <div className="space-y-2">
+        {/* Source */}
+        <div className="flex items-center gap-2">
+          {event.sources.length > 0 && (
+            <SourceLogo sourceId={event.sources[0]} />
+          )}
+          <span className="text-sm font-semibold text-foreground truncate">
+            {sources.find((s) => s.id === event.sources[0])?.name ||
+              event.sources[0] ||
+              "Неизвестен"}
+          </span>
+        </div>
+
+        {/* Categories */}
+        {event.categories && event.categories.length > 0 && (
+          <CategoryChips categories={event.categories} />
+        )}
+
+        {/* Text */}
+        <p className="text-sm text-neutral leading-relaxed">{snippet}</p>
+
+        {/* Timespan */}
+        {timespan && <p className="text-xs text-neutral">{timespan}</p>}
+      </div>
+    </div>
+  );
+}
+
+function EventCardSkeleton() {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 border border-neutral-border animate-pulse">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <div className="w-6 h-6 bg-neutral-light rounded" />
+          <div className="h-4 bg-neutral-light rounded w-1/3" />
+        </div>
+        <div className="flex gap-2">
+          <div className="h-5 w-16 bg-neutral-light rounded-full" />
+          <div className="h-5 w-20 bg-neutral-light rounded-full" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 bg-neutral-light rounded w-full" />
+          <div className="h-3 bg-neutral-light rounded w-5/6" />
+        </div>
+        <div className="h-3 bg-neutral-light rounded w-1/4" />
+      </div>
+    </div>
+  );
+}
+
+export default function EventsPage() {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    error,
+  } = useInfiniteQuery({
+    queryKey: ["events"],
+    queryFn: fetchEvents,
+    initialPageParam: undefined as EventsCursor | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+
+  const events = useMemo(
+    () => data?.pages.flatMap((page) => page.events) ?? [],
+    [data],
+  );
+
+  const isEmpty = !isLoading && events.length === 0;
+
+  return (
+    <div className="min-h-screen bg-neutral-light">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Back link */}
+        <div className="mb-6">
+          <Link
+            href="/"
+            className="text-primary hover:text-primary-hover inline-flex items-center gap-2"
+          >
+            <span>←</span>
+            <span>Начало</span>
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6 mb-8 border border-neutral-border">
+          <div className="space-y-2">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
+              Групирани съобщения
+            </h1>
+            <p className="text-sm text-neutral">
+              Съобщенията са групирани по реални събития. Всяко събитие обединява
+              свързани съобщения от различни източници. Разгъни събитие, за да
+              видиш включените съобщения и тяхната увереност на съвпадение.
+            </p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-md border border-error-border bg-error-light p-4 text-error">
+            Грешка при зареждане на събитията. Опитай отново.
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {isLoading &&
+            Array.from({ length: 6 }, (_, i) => (
+              <EventCardSkeleton key={`skeleton-${i}`} />
+            ))}
+
+          {!isLoading &&
+            events.map((event) =>
+              event.messageCount === 1 ? (
+                <SingleEventCard key={event.id} event={event} />
+              ) : (
+                <EventAccordion key={event.id} event={event} />
+              ),
+            )}
+
+          {isEmpty && (
+            <div className="text-center text-neutral py-8">
+              Няма налични групирани съобщения.
+            </div>
+          )}
+        </div>
+
+        {hasNextPage && (
+          <div className="mt-8 flex justify-center">
+            <button
+              type="button"
+              onClick={() => fetchNextPage()}
+              className={getButtonClasses("ghost", "lg", "sm")}
+              disabled={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? "Зареждане..." : "Покажи още"}
+            </button>
+          </div>
+        )}
+
+        {isFetchingNextPage && (
+          <div className="mt-6 space-y-4">
+            {Array.from({ length: 3 }, (_, i) => (
+              <EventCardSkeleton key={`loading-${i}`} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/events/page.tsx
+++ b/web/app/events/page.tsx
@@ -3,13 +3,14 @@
 import { useMemo } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import Image from "next/image";
-import { useState } from "react";
 import type { Event } from "@oboapp/shared";
 import sources from "@/lib/sources.json";
 import { stripMarkdown } from "@/lib/markdown-utils";
 import { getButtonClasses } from "@/lib/theme";
+import { formatTimespan } from "@/lib/date-format";
+import { createSnippet } from "@/lib/text-utils";
 import CategoryChips from "@/components/CategoryChips";
+import SourceLogo from "@/components/SourceLogo";
 import EventAccordion from "@/components/EventAccordion";
 
 type EventsCursor = {
@@ -40,60 +41,10 @@ const fetchEvents = async ({
   return response.json();
 };
 
-function formatDate(dateStr: string | undefined): string {
-  if (!dateStr) return "";
-  const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) return "";
-  const day = date.getDate().toString().padStart(2, "0");
-  const month = (date.getMonth() + 1).toString().padStart(2, "0");
-  const year = date.getFullYear();
-  return `${day}.${month}.${year}`;
-}
-
-function formatTimespan(
-  start: string | undefined,
-  end: string | undefined,
-): string {
-  const startStr = formatDate(start);
-  const endStr = formatDate(end);
-  if (startStr && endStr && startStr !== endStr) return `${startStr} – ${endStr}`;
-  if (startStr) return startStr;
-  if (endStr) return endStr;
-  return "";
-}
-
-function SourceLogo({ sourceId }: { readonly sourceId: string }) {
-  const [error, setError] = useState(false);
-  const sourceInfo = sources.find((s) => s.id === sourceId);
-  const logoPath = `/sources/${sourceId}.png`;
-
-  if (error) {
-    return (
-      <span className="text-xs text-neutral truncate">
-        {sourceInfo?.name || sourceId}
-      </span>
-    );
-  }
-
-  return (
-    <Image
-      src={logoPath}
-      alt={sourceInfo?.name || sourceId}
-      width={24}
-      height={24}
-      className="w-6 h-6 object-contain flex-shrink-0"
-      onError={() => setError(true)}
-    />
-  );
-}
-
 function SingleEventCard({ event }: { readonly event: Event }) {
   const displayText = event.markdownText || event.plainText;
   const clean = stripMarkdown(displayText);
-  const snippet =
-    clean.length > 150
-      ? clean.substring(0, clean.lastIndexOf(" ", 150) > 120 ? clean.lastIndexOf(" ", 150) : 150) + "..."
-      : clean;
+  const snippet = createSnippet(clean, 150);
   const timespan = formatTimespan(event.timespanStart, event.timespanEnd);
 
   return (
@@ -102,7 +53,11 @@ function SingleEventCard({ event }: { readonly event: Event }) {
         {/* Source */}
         <div className="flex items-center gap-2">
           {event.sources.length > 0 && (
-            <SourceLogo sourceId={event.sources[0]} />
+            <SourceLogo
+              sourceId={event.sources[0]}
+              size={24}
+              showFallbackText
+            />
           )}
           <span className="text-sm font-semibold text-foreground truncate">
             {sources.find((s) => s.id === event.sources[0])?.name ||
@@ -190,9 +145,10 @@ export default function EventsPage() {
               Групирани съобщения
             </h1>
             <p className="text-sm text-neutral">
-              Съобщенията са групирани по реални събития. Всяко събитие обединява
-              свързани съобщения от различни източници. Разгъни събитие, за да
-              видиш включените съобщения и тяхната увереност на съвпадение.
+              Съобщенията са групирани по реални събития. Всяко събитие
+              обединява свързани съобщения от различни източници. Разгъни
+              събитие, за да видиш включените съобщения и тяхната увереност на
+              съвпадение.
             </p>
           </div>
         </div>

--- a/web/app/history/HistoryContent.tsx
+++ b/web/app/history/HistoryContent.tsx
@@ -4,14 +4,7 @@ import { useState, useCallback } from "react";
 import HistoryMapWrapper from "./HistoryMapWrapper";
 import HistoryFilterModal from "./HistoryFilterModal";
 import type { HeatmapStats } from "./HistoryMapClient";
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("bg-BG", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
+import { formatDate } from "@/lib/date-format";
 
 /**
  * Client component that owns the filter state for the history heatmap page.
@@ -37,10 +30,7 @@ export default function HistoryContent() {
 
   const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
 
-  function handleApplyFilters(
-    categories: Set<string>,
-    sources: Set<string>,
-  ) {
+  function handleApplyFilters(categories: Set<string>, sources: Set<string>) {
     // Shallow-compare to avoid triggering a re-fetch when nothing changed
     setSelectedCategories((prev) => {
       if (

--- a/web/components/EventAccordion.tsx
+++ b/web/components/EventAccordion.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useId } from "react";
+import Image from "next/image";
+import { ChevronDown } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { Event, Message, EventMessage } from "@oboapp/shared";
+import sources from "@/lib/sources.json";
+import { stripMarkdown } from "@/lib/markdown-utils";
+import CategoryChips from "@/components/CategoryChips";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
+interface EventAccordionProps {
+  readonly event: Event;
+}
+
+type EventMessagesResponse = {
+  messages: Message[];
+  eventMessages: EventMessage[];
+};
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  const day = date.getDate().toString().padStart(2, "0");
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const year = date.getFullYear();
+  return `${day}.${month}.${year}`;
+}
+
+function formatTimespan(
+  start: string | undefined,
+  end: string | undefined,
+): string {
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+  if (startStr && endStr && startStr !== endStr) return `${startStr} – ${endStr}`;
+  if (startStr) return startStr;
+  if (endStr) return endStr;
+  return "";
+}
+
+function createSnippet(text: string, maxLength = 150): string {
+  const clean = stripMarkdown(text);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.substring(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > 120) return truncated.substring(0, lastSpace) + "...";
+  return truncated + "...";
+}
+
+function SourceLogo({ sourceId }: { readonly sourceId: string }) {
+  const [error, setError] = useState(false);
+  const logoPath = `/sources/${sourceId}.png`;
+  const sourceInfo = sources.find((s) => s.id === sourceId);
+
+  if (error) return null;
+
+  return (
+    <Image
+      src={logoPath}
+      alt={sourceInfo?.name || sourceId}
+      width={20}
+      height={20}
+      className="w-5 h-5 object-contain flex-shrink-0"
+      onError={() => setError(true)}
+    />
+  );
+}
+
+function formatConfidence(confidence: number): string {
+  return `${Math.round(confidence * 100)}%`;
+}
+
+function MessageRow({
+  message,
+  eventMessage,
+}: {
+  readonly message: Message;
+  readonly eventMessage: EventMessage | undefined;
+}) {
+  const sourceInfo = sources.find((s) => s.id === message.source);
+  const displayText = message.markdownText || message.text;
+  const snippet = createSnippet(displayText, 120);
+
+  return (
+    <div className="flex items-start gap-3 py-2 px-3 border-b border-neutral-border last:border-b-0">
+      <div className="flex-shrink-0 mt-0.5">
+        {message.source && <SourceLogo sourceId={message.source} />}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-xs font-medium text-neutral-dark truncate">
+            {sourceInfo?.name || message.source || "Неизвестен"}
+          </span>
+          {eventMessage && (
+            <span
+              className="text-xs text-neutral flex-shrink-0"
+              title="Увереност на съвпадението"
+            >
+              {formatConfidence(eventMessage.confidence)}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-neutral leading-relaxed">{snippet}</p>
+      </div>
+    </div>
+  );
+}
+
+function EventMessagesBody({ eventId }: { readonly eventId: string }) {
+  const { data, isLoading, error } = useQuery<EventMessagesResponse>({
+    queryKey: ["eventMessages", eventId],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(
+        `/api/events/messages?eventId=${encodeURIComponent(eventId)}`,
+        { signal },
+      );
+      if (!res.ok) throw new Error("Failed to fetch event messages");
+      return res.json();
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-3 py-2 text-xs text-error">
+        Грешка при зареждане на съобщенията.
+      </div>
+    );
+  }
+
+  if (!data || data.messages.length === 0) {
+    return (
+      <div className="px-3 py-2 text-xs text-neutral">Няма съобщения.</div>
+    );
+  }
+
+  const eventMessagesByMessageId = new Map(
+    data.eventMessages.map((em) => [em.messageId, em]),
+  );
+
+  return (
+    <div>
+      {data.messages.map((message) => (
+        <MessageRow
+          key={message.id}
+          message={message}
+          eventMessage={eventMessagesByMessageId.get(message.id || "")}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default function EventAccordion({ event }: EventAccordionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+  const titleId = useId();
+
+  const snippet = createSnippet(event.plainText, 200);
+  const timespan = formatTimespan(event.timespanStart, event.timespanEnd);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md border border-neutral-border overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full text-left p-4 hover:bg-neutral-light/50 transition-colors cursor-pointer"
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            {/* Header row: text + badge */}
+            <div className="flex items-center gap-2 mb-1">
+              <span
+                id={titleId}
+                className="text-sm font-semibold text-foreground line-clamp-2"
+              >
+                {snippet}
+              </span>
+              <span className="flex-shrink-0 inline-flex items-center justify-center bg-info-light text-info text-xs font-medium px-2 py-0.5 rounded-full">
+                {event.messageCount}
+              </span>
+            </div>
+
+            {/* Categories */}
+            {event.categories && event.categories.length > 0 && (
+              <div className="mb-2">
+                <CategoryChips categories={event.categories} />
+              </div>
+            )}
+
+            {/* Meta row: sources + timespan */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral">
+              {/* Source logos */}
+              <div className="flex items-center gap-1">
+                {event.sources.map((sourceId) => (
+                  <SourceLogo key={sourceId} sourceId={sourceId} />
+                ))}
+              </div>
+
+              {timespan && <span>{timespan}</span>}
+            </div>
+          </div>
+
+          <ChevronDown
+            className={`w-4 h-4 text-neutral transition-transform flex-shrink-0 mt-1 ${
+              isOpen ? "rotate-180" : ""
+            }`}
+          />
+        </div>
+      </button>
+
+      {isOpen && (
+        <div
+          id={contentId}
+          role="region"
+          aria-labelledby={titleId}
+          className="border-t border-neutral-border bg-neutral-light/30"
+        >
+          <EventMessagesBody eventId={event.id!} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/EventAccordion.tsx
+++ b/web/components/EventAccordion.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useState, useId } from "react";
-import Image from "next/image";
 import { ChevronDown } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import type { Event, Message, EventMessage } from "@oboapp/shared";
 import sources from "@/lib/sources.json";
 import { stripMarkdown } from "@/lib/markdown-utils";
+import { createSnippet } from "@/lib/text-utils";
+import { formatTimespan } from "@/lib/date-format";
 import CategoryChips from "@/components/CategoryChips";
+import SourceLogo from "@/components/SourceLogo";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
 interface EventAccordionProps {
@@ -19,54 +21,9 @@ type EventMessagesResponse = {
   eventMessages: EventMessage[];
 };
 
-function formatDate(dateStr: string | undefined): string {
-  if (!dateStr) return "";
-  const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) return "";
-  const day = date.getDate().toString().padStart(2, "0");
-  const month = (date.getMonth() + 1).toString().padStart(2, "0");
-  const year = date.getFullYear();
-  return `${day}.${month}.${year}`;
-}
-
-function formatTimespan(
-  start: string | undefined,
-  end: string | undefined,
-): string {
-  const startStr = formatDate(start);
-  const endStr = formatDate(end);
-  if (startStr && endStr && startStr !== endStr) return `${startStr} – ${endStr}`;
-  if (startStr) return startStr;
-  if (endStr) return endStr;
-  return "";
-}
-
-function createSnippet(text: string, maxLength = 150): string {
+function makeSnippet(text: string, maxLength = 150): string {
   const clean = stripMarkdown(text);
-  if (clean.length <= maxLength) return clean;
-  const truncated = clean.substring(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(" ");
-  if (lastSpace > 120) return truncated.substring(0, lastSpace) + "...";
-  return truncated + "...";
-}
-
-function SourceLogo({ sourceId }: { readonly sourceId: string }) {
-  const [error, setError] = useState(false);
-  const logoPath = `/sources/${sourceId}.png`;
-  const sourceInfo = sources.find((s) => s.id === sourceId);
-
-  if (error) return null;
-
-  return (
-    <Image
-      src={logoPath}
-      alt={sourceInfo?.name || sourceId}
-      width={20}
-      height={20}
-      className="w-5 h-5 object-contain flex-shrink-0"
-      onError={() => setError(true)}
-    />
-  );
+  return createSnippet(clean, maxLength);
 }
 
 function formatConfidence(confidence: number): string {
@@ -82,7 +39,7 @@ function MessageRow({
 }) {
   const sourceInfo = sources.find((s) => s.id === message.source);
   const displayText = message.markdownText || message.text;
-  const snippet = createSnippet(displayText, 120);
+  const snippet = makeSnippet(displayText, 120);
 
   return (
     <div className="flex items-start gap-3 py-2 px-3 border-b border-neutral-border last:border-b-0">
@@ -166,7 +123,7 @@ export default function EventAccordion({ event }: EventAccordionProps) {
   const contentId = useId();
   const titleId = useId();
 
-  const snippet = createSnippet(event.plainText, 200);
+  const snippet = makeSnippet(event.plainText, 200);
   const timespan = formatTimespan(event.timespanStart, event.timespanEnd);
 
   return (

--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -11,10 +11,10 @@ export default function Footer({ className = "" }: FooterProps) {
   return (
     <footer className={`border-t border-neutral-border ${className}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Navigation links — 1 col mobile, 2 col sm, 5 col lg */}
+        {/* Navigation links — 1 col mobile, 2 col sm, 3 col lg */}
         <div>
           <h3 className="font-bold text-lg mb-4 text-foreground">За OboApp</h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-x-8 gap-y-2 text-sm">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-2 text-sm">
             <div>
               <Link
                 href="/kak-se-rodi"

--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -55,6 +55,14 @@ export default function Footer({ className = "" }: FooterProps) {
                 Нечетими съобщения
               </Link>
             </div>
+            <div>
+              <Link
+                href="/events"
+                className="text-link hover:text-link-hover hover:underline"
+              >
+                Групирани съобщения
+              </Link>
+            </div>
           </div>
         </div>
 

--- a/web/components/SourceLogo.tsx
+++ b/web/components/SourceLogo.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import sources from "@/lib/sources.json";
+
+interface SourceLogoProps {
+  readonly sourceId: string;
+  readonly size?: number;
+  readonly showFallbackText?: boolean;
+}
+
+export default function SourceLogo({
+  sourceId,
+  size = 20,
+  showFallbackText = false,
+}: SourceLogoProps) {
+  const [error, setError] = useState(false);
+  const logoPath = `/sources/${sourceId}.png`;
+  const sourceInfo = sources.find((s) => s.id === sourceId);
+
+  if (error) {
+    if (!showFallbackText) return null;
+    return (
+      <span className="text-xs text-neutral truncate">
+        {sourceInfo?.name || sourceId}
+      </span>
+    );
+  }
+
+  return (
+    <Image
+      src={logoPath}
+      alt={sourceInfo?.name || sourceId}
+      width={size}
+      height={size}
+      className="object-contain flex-shrink-0"
+      style={{ width: size, height: size }}
+      onError={() => setError(true)}
+    />
+  );
+}

--- a/web/lib/bounds-utils.ts
+++ b/web/lib/bounds-utils.ts
@@ -4,16 +4,22 @@
 
 import * as turf from "@turf/turf";
 import type { GeoJSONFeature } from "@/lib/types";
-import { BOUNDS, getBoundsForLocality, getCenterForLocality } from "@oboapp/shared";
+import {
+  BOUNDS,
+  getBoundsForLocality,
+  getCenterForLocality,
+} from "@oboapp/shared";
 
 /**
  * Get locality from environment variable
  * @throws Error if NEXT_PUBLIC_LOCALITY is not set
  */
-function getLocality(): string {
+export function getLocality(): string {
   const locality = process.env.NEXT_PUBLIC_LOCALITY;
   if (!locality) {
-    throw new Error("NEXT_PUBLIC_LOCALITY environment variable is required but not set");
+    throw new Error(
+      "NEXT_PUBLIC_LOCALITY environment variable is required but not set",
+    );
   }
   return locality;
 }

--- a/web/lib/date-format.ts
+++ b/web/lib/date-format.ts
@@ -1,0 +1,29 @@
+/**
+ * Format an ISO date string as DD.MM.YYYY using Bulgarian locale.
+ */
+export function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("bg-BG", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+/**
+ * Format a start–end date range as a human-readable string.
+ */
+export function formatTimespan(
+  start: string | undefined,
+  end: string | undefined,
+): string {
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+  if (startStr && endStr && startStr !== endStr)
+    return `${startStr} – ${endStr}`;
+  if (startStr) return startStr;
+  if (endStr) return endStr;
+  return "";
+}


### PR DESCRIPTION
Fixes #262 
- Introduced event aggregation with static mock data for events and event messages.
- Added API endpoints for fetching events and linked messages.
- Created a new `/events` page with infinite scrolling and event accordions.
- Updated the footer to include a link to the new grouped events page.
- Enhanced existing documentation to reflect changes in architecture and coverage.
<img width="1728" height="883" alt="Screenshot 2026-03-19 at 14 25 33" src="https://github.com/user-attachments/assets/0108cec5-782c-4b7c-8bd7-e20c43f83d15" />
