### PR TITLE
fix(geocoding): skip empty endpoints in intersection geocoding

### DIFF
--- a/ingest/geocoding/router.test.ts
+++ b/ingest/geocoding/router.test.ts
@@ -212,8 +212,7 @@ describe("hasHouseNumber", () => {
 
 describe("geocodeIntersectionsForStreets", () => {
   it("should skip endpoints already in preGeocodedMap", async () => {
-    const { geocodeIntersectionsForStreets } =
-      await import("./router");
+    const { geocodeIntersectionsForStreets } = await import("./router");
     const { overpassGeocodeIntersections, overpassGeocodeAddresses } =
       await import("./overpass/service");
 
@@ -261,8 +260,7 @@ describe("geocodeIntersectionsForStreets", () => {
   });
 
   it("should work without preGeocodedMap (backward compatibility)", async () => {
-    const { geocodeIntersectionsForStreets } =
-      await import("./router");
+    const { geocodeIntersectionsForStreets } = await import("./router");
     const { overpassGeocodeIntersections, overpassGeocodeAddresses } =
       await import("./overpass/service");
 
@@ -311,5 +309,42 @@ describe("geocodeIntersectionsForStreets", () => {
     expect(result.size).toBe(2);
     expect(result.get("Cross A")).toEqual({ lat: 42.0, lng: 23.0 });
     expect(result.get("Cross B")).toEqual({ lat: 42.7, lng: 23.3 });
+  });
+
+  it("should skip empty 'from' and 'to' endpoints without calling Overpass", async () => {
+    const { geocodeIntersectionsForStreets } = await import("./router");
+    const { overpassGeocodeIntersections, overpassGeocodeAddresses } =
+      await import("./overpass/service");
+
+    const mockOverpassGeocodeIntersections = vi.mocked(
+      overpassGeocodeIntersections,
+    );
+    const mockOverpassGeocodeAddresses = vi.mocked(overpassGeocodeAddresses);
+
+    mockOverpassGeocodeIntersections.mockResolvedValue([]);
+    mockOverpassGeocodeAddresses.mockResolvedValue([]);
+
+    const streets = [
+      {
+        street: "ул. Main",
+        from: "", // empty — must be skipped
+        to: "Cross B",
+        timespans: [{ start: "2024-01-01", end: "2024-01-02" }],
+      },
+      {
+        street: "ул. Second",
+        from: "Cross C",
+        to: "   ", // whitespace-only — must be skipped
+        timespans: [{ start: "2024-01-01", end: "2024-01-02" }],
+      },
+    ];
+
+    await geocodeIntersectionsForStreets(streets);
+
+    // Only Cross B should produce an intersection query; empty / blank endpoints must not
+    expect(mockOverpassGeocodeIntersections).toHaveBeenCalledWith([
+      "ул. Main ∩ Cross B",
+      "ул. Second ∩ Cross C",
+    ]);
   });
 });

--- a/ingest/geocoding/router.test.ts
+++ b/ingest/geocoding/router.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
 // Mock Firebase-dependent imports to avoid initialization errors
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 vi.mock("./gtfs/geocoding-service", () => ({
   geocodeBusStops: vi.fn(),
 }));
@@ -311,15 +315,17 @@ describe("geocodeIntersectionsForStreets", () => {
     expect(result.get("Cross B")).toEqual({ lat: 42.7, lng: 23.3 });
   });
 
-  it("should skip empty 'from' and 'to' endpoints without calling Overpass", async () => {
+  it("should not call Overpass for empty or whitespace-only endpoints", async () => {
     const { geocodeIntersectionsForStreets } = await import("./router");
     const { overpassGeocodeIntersections, overpassGeocodeAddresses } =
       await import("./overpass/service");
+    const { logger } = await import("@/lib/logger");
 
     const mockOverpassGeocodeIntersections = vi.mocked(
       overpassGeocodeIntersections,
     );
     const mockOverpassGeocodeAddresses = vi.mocked(overpassGeocodeAddresses);
+    const mockWarn = vi.mocked(logger.warn);
 
     mockOverpassGeocodeIntersections.mockResolvedValue([]);
     mockOverpassGeocodeAddresses.mockResolvedValue([]);
@@ -341,10 +347,20 @@ describe("geocodeIntersectionsForStreets", () => {
 
     await geocodeIntersectionsForStreets(streets);
 
-    // Only Cross B should produce an intersection query; empty / blank endpoints must not
+    // Valid endpoints still produce intersection queries; empty/blank ones do not
     expect(mockOverpassGeocodeIntersections).toHaveBeenCalledWith([
       "ул. Main ∩ Cross B",
       "ул. Second ∩ Cross C",
     ]);
+
+    // A warn must be emitted for each skipped endpoint
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Skipping empty endpoint in intersection geocoding",
+      { street: "ул. Main", endpoint: "" },
+    );
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Skipping empty endpoint in intersection geocoding",
+      { street: "ул. Second", endpoint: "   " },
+    );
   });
 });

--- a/ingest/geocoding/router.ts
+++ b/ingest/geocoding/router.ts
@@ -132,6 +132,7 @@ export async function geocodeIntersectionsForStreets(
     if (!endpoint.trim()) {
       logger.warn("Skipping empty endpoint in intersection geocoding", {
         street: streetName,
+        endpoint,
       });
     } else if (hasHouseNumber(endpoint)) {
       houseNumberEndpoints.set(endpoint, streetName);

--- a/ingest/geocoding/router.ts
+++ b/ingest/geocoding/router.ts
@@ -59,8 +59,7 @@ export async function getStreetGeometry(
   startCoords: Coordinates,
   endCoords: Coordinates,
 ): Promise<[number, number][] | null> {
-  const { getStreetSectionGeometry } =
-    await import("./overpass/service");
+  const { getStreetSectionGeometry } = await import("./overpass/service");
   const geometry = await getStreetSectionGeometry(
     streetName,
     startCoords,
@@ -128,36 +127,26 @@ export async function geocodeIntersectionsForStreets(
   const intersections: string[] = [];
   const houseNumberEndpoints = new Map<string, string>(); // endpoint -> street name
 
-  streets.forEach((street) => {
-    // "from" endpoint - only process if not already geocoded
-    // Skip endpoints already in preGeocodedMap to avoid redundant Overpass/Nominatim API calls
-    if (!preGeocodedMap?.has(street.from)) {
-      if (hasHouseNumber(street.from)) {
-        // Track street context for house-number endpoints to avoid ambiguous queries
-        houseNumberEndpoints.set(street.from, street.street);
-      } else {
-        const fromIntersection = `${street.street} ∩ ${street.from}`;
-        if (!intersectionSet.has(fromIntersection)) {
-          intersectionSet.add(fromIntersection);
-          intersections.push(fromIntersection);
-        }
+  function processEndpoint(endpoint: string, streetName: string): void {
+    if (preGeocodedMap?.has(endpoint)) return;
+    if (!endpoint.trim()) {
+      logger.warn("Skipping empty endpoint in intersection geocoding", {
+        street: streetName,
+      });
+    } else if (hasHouseNumber(endpoint)) {
+      houseNumberEndpoints.set(endpoint, streetName);
+    } else {
+      const intersection = `${streetName} ∩ ${endpoint}`;
+      if (!intersectionSet.has(intersection)) {
+        intersectionSet.add(intersection);
+        intersections.push(intersection);
       }
     }
+  }
 
-    // "to" endpoint - only process if not already geocoded
-    // Skip endpoints already in preGeocodedMap to avoid redundant Overpass/Nominatim API calls
-    if (!preGeocodedMap?.has(street.to)) {
-      if (hasHouseNumber(street.to)) {
-        // Track street context for house-number endpoints to avoid ambiguous queries
-        houseNumberEndpoints.set(street.to, street.street);
-      } else {
-        const toIntersection = `${street.street} ∩ ${street.to}`;
-        if (!intersectionSet.has(toIntersection)) {
-          intersectionSet.add(toIntersection);
-          intersections.push(toIntersection);
-        }
-      }
-    }
+  streets.forEach((street) => {
+    processEndpoint(street.from, street.street);
+    processEndpoint(street.to, street.street);
   });
 
   // Geocode cross-street intersections via Overpass


### PR DESCRIPTION
Fixes #331

## What

When the LLM extraction stage produces an incomplete intersection where one street name is empty, the geocoding router now silently skips that endpoint instead of forwarding an empty string to Overpass.

## Why

An empty street name causes an Overpass API call that will always fail, but still consumes the 500 ms rate-limit delay. Skipping early avoids both the wasted round-trip and the delay.

## Changes

- `ingest/geocoding/router.ts` — added an early guard: if `endpoint.trim()` is falsy, emit `logger.warn` and skip. Also extracted the duplicated from/to logic into a `processEndpoint` inner function.
- `ingest/geocoding/router.test.ts` — added a test covering `from: ""` (empty) and `to: "   "` (whitespace-only); asserts only valid queries reach Overpass.