### PR TITLE
feat(geocoding): add in-memory cache for Overpass street geometry lookups

### DIFF
--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   normalizeAddressForNominatim,
   normalizeStreetName,
   toOverpassRegex,
+  clearStreetGeometryCache,
 } from "./service";
 
 describe("overpass-geocoding-service", () => {
@@ -295,6 +296,22 @@ describe("overpass-geocoding-service", () => {
       expect(normalizeAddressForNominatim("бл. 12, ж.к. Младост")).toBe(
         "бл. 12, ж.к. Младост",
       );
+    });
+  });
+
+  describe("clearStreetGeometryCache", () => {
+    beforeEach(() => {
+      clearStreetGeometryCache();
+    });
+
+    it("does not throw when cache is empty", () => {
+      expect(() => clearStreetGeometryCache()).not.toThrow();
+    });
+
+    it("can be called multiple times safely", () => {
+      clearStreetGeometryCache();
+      clearStreetGeometryCache();
+      expect(() => clearStreetGeometryCache()).not.toThrow();
     });
   });
 });

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -370,5 +370,20 @@ describe("overpass-geocoding-service", () => {
       // ул. Фоо is already cached (way:фоо) → only 1 fresh fetch
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    it("clearing the cache causes a subsequent lookup to hit the network again", async () => {
+      const fetchMock = mockFetch(wayResponse);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      clearStreetGeometryCache();
+      fetchMock.mockClear();
+
+      // Both streets were cleared — should fetch them again
+      await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   normalizeAddressForNominatim,
   normalizeStreetName,
   toOverpassRegex,
   clearStreetGeometryCache,
+  overpassGeocodeIntersections,
 } from "./service";
+
+// Prevent the 500ms inter-item delay from slowing down the test suite
+vi.mock("../../lib/delay", () => ({ delay: vi.fn().mockResolvedValue(undefined) }));
 
 describe("overpass-geocoding-service", () => {
   describe("parseOverpassError", () => {
@@ -299,19 +303,72 @@ describe("overpass-geocoding-service", () => {
     });
   });
 
-  describe("clearStreetGeometryCache", () => {
+  describe("streetGeometryCache", () => {
+    const wayResponse = JSON.stringify({
+      elements: [
+        {
+          type: "way",
+          geometry: [
+            { lat: 42.6977, lon: 23.3219 },
+            { lat: 42.698, lon: 23.3225 },
+          ],
+        },
+      ],
+    });
+    const emptyResponse = JSON.stringify({ elements: [] });
+
+    function mockFetch(responseBody: string) {
+      return vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(responseBody),
+      });
+    }
+
     beforeEach(() => {
       clearStreetGeometryCache();
     });
 
-    it("does not throw when cache is empty", () => {
-      expect(() => clearStreetGeometryCache()).not.toThrow();
+    afterEach(() => {
+      vi.unstubAllGlobals();
     });
 
-    it("can be called multiple times safely", () => {
-      clearStreetGeometryCache();
-      clearStreetGeometryCache();
-      expect(() => clearStreetGeometryCache()).not.toThrow();
+    it("deduplicates Overpass fetches when the same street appears in multiple intersections", async () => {
+      vi.stubGlobal("fetch", mockFetch(wayResponse));
+
+      await overpassGeocodeIntersections([
+        "ул. Пример ∩ ул. Фоо",
+        "ул. Пример ∩ ул. Бар",
+      ]);
+
+      // 3 unique streets (ул. Пример, ул. Фоо, ул. Бар) — ул. Пример fetched only once
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("caches null results and skips re-fetching streets not found in OSM", async () => {
+      vi.stubGlobal("fetch", mockFetch(emptyResponse));
+
+      await overpassGeocodeIntersections([
+        "ул. Пример ∩ ул. Фоо",
+        "ул. Пример ∩ ул. Бар",
+      ]);
+
+      // Same deduplication applies even when results are null
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("uses separate cache entries for streets vs squares with the same normalized name", async () => {
+      const fetchMock = mockFetch(wayResponse);
+      vi.stubGlobal("fetch", fetchMock);
+
+      // Both normalize to the same string, but use different Overpass queries
+      await overpassGeocodeIntersections(["ул. Свобода ∩ ул. Фоо"]);
+      fetchMock.mockClear();
+
+      // A square lookup for the same normalized name should still go to the network
+      await overpassGeocodeIntersections(["пл. Свобода ∩ ул. Фоо"]);
+      // пл. Свобода is a square — NOT served from the way cache (different key square:свобода vs way:свобода)
+      // ул. Фоо is already cached (way:фоо) → only 1 fresh fetch
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -27,7 +27,22 @@ const OVERPASS_DELAY_MS = 500; // 500ms for Overpass API (generous limits)
 const OVERPASS_TIMEOUT_MS = 25000; // 25 seconds timeout for HTTP requests
 const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
-// In-memory cache for street geometry lookups (keyed on normalized street name)
+type StreetGeometryFeatureType = "way" | "square" | "area";
+
+/**
+ * Build a cache key for street geometry lookups that includes both the
+ * detected feature type and the normalized street name. This avoids
+ * collisions between different feature types that share the same
+ * normalized name (e.g. "ул. Свобода" vs "пл. Свобода").
+ */
+export function makeStreetGeometryCacheKey(
+  featureType: StreetGeometryFeatureType,
+  normalizedStreetName: string,
+): string {
+  return `${featureType}:${normalizedStreetName}`;
+}
+
+// In-memory cache for street geometry lookups (keyed on type + normalized street name)
 const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
 
 /** Clear the street geometry cache. Exported for test isolation. */
@@ -137,16 +152,20 @@ async function getStreetGeometryFromOverpass(
     // Normalize street name for better OSM matching
     const normalizedName = normalizeStreetName(streetName);
 
+    // Determine feature type — needed both for the cache key and the Overpass query
+    const isSquare = Boolean(
+      streetName.toLowerCase().match(/^(площад|пл\.)\s*/),
+    );
+    const featureType: StreetGeometryFeatureType = isSquare ? "square" : "way";
+    const cacheKey = makeStreetGeometryCacheKey(featureType, normalizedName);
+
     // Return cached result if available (includes null for streets not found in OSM)
-    if (streetGeometryCache.has(normalizedName)) {
-      logger.info("Street geometry cache hit", { streetName, normalizedName });
-      return streetGeometryCache.get(normalizedName)!;
+    if (streetGeometryCache.has(cacheKey)) {
+      logger.debug("Street geometry cache hit", { streetName, normalizedName });
+      return streetGeometryCache.get(cacheKey)!;
     }
 
     const queryRegex = toOverpassRegex(normalizedName);
-
-    // Check if this is a square/plaza (площад/пл.)
-    const isSquare = streetName.toLowerCase().match(/^(площад|пл\.)\s*/);
 
     // Overpass QL query to find the street by name
     // For squares, search for place=square nodes/areas
@@ -282,7 +301,7 @@ async function getStreetGeometryFromOverpass(
     if (!responseData.elements || responseData.elements.length === 0) {
       // No OSM ways found - API request succeeded but no data for this street name
       logger.info("Could not find street in OSM", { streetName });
-      streetGeometryCache.set(normalizedName, null);
+      streetGeometryCache.set(cacheKey, null);
       return null;
     }
 
@@ -325,7 +344,7 @@ async function getStreetGeometryFromOverpass(
 
     if (lineStrings.length === 0) {
       logger.info("No valid geometries in response", { streetName });
-      streetGeometryCache.set(normalizedName, null);
+      streetGeometryCache.set(cacheKey, null);
       return null;
     }
 
@@ -344,7 +363,7 @@ async function getStreetGeometryFromOverpass(
       },
     };
 
-    streetGeometryCache.set(normalizedName, multiLineString);
+    streetGeometryCache.set(cacheKey, multiLineString);
     return multiLineString;
   } catch (error) {
     logger.error("Error fetching from Overpass", {

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -27,15 +27,15 @@ const OVERPASS_DELAY_MS = 500; // 500ms for Overpass API (generous limits)
 const OVERPASS_TIMEOUT_MS = 25000; // 25 seconds timeout for HTTP requests
 const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
-type StreetGeometryFeatureType = "way" | "square" | "area";
+type StreetGeometryFeatureType = "street" | "boulevard" | "square";
 
 /**
- * Build a cache key for street geometry lookups that includes both the
- * detected feature type and the normalized street name. This avoids
- * collisions between different feature types that share the same
- * normalized name (e.g. "ул. Свобода" vs "пл. Свобода").
+ * Build a cache key that encodes both the query variant and the normalized
+ * street name, preventing collisions between lookups that use different
+ * Overpass queries for the same normalized name
+ * (e.g. "ул. България" uses a wider highway filter than "бул. България").
  */
-export function makeStreetGeometryCacheKey(
+function makeStreetGeometryCacheKey(
   featureType: StreetGeometryFeatureType,
   normalizedStreetName: string,
 ): string {
@@ -152,11 +152,18 @@ async function getStreetGeometryFromOverpass(
     // Normalize street name for better OSM matching
     const normalizedName = normalizeStreetName(streetName);
 
-    // Determine feature type — needed both for the cache key and the Overpass query
+    // Determine query variant — needed both for the cache key and the Overpass query.
+    // isSquare uses place=square OSM tags; isStreet broadens the highway filter to
+    // include residential/unclassified/living_street (prefixed with "ул.").
     const isSquare = Boolean(
       streetName.toLowerCase().match(/^(площад|пл\.)\s*/),
     );
-    const featureType: StreetGeometryFeatureType = isSquare ? "square" : "way";
+    const isStreet = !isSquare && streetName.toLowerCase().includes("ул.");
+    const featureType: StreetGeometryFeatureType = isSquare
+      ? "square"
+      : isStreet
+        ? "street"
+        : "boulevard";
     const cacheKey = makeStreetGeometryCacheKey(featureType, normalizedName);
 
     // Return cached result if available (includes null for streets not found in OSM)
@@ -170,7 +177,6 @@ async function getStreetGeometryFromOverpass(
     // Overpass QL query to find the street by name
     // For squares, search for place=square nodes/areas
     // For streets (ул.), include residential roads in addition to main highways
-    const isStreet = streetName.toLowerCase().includes("ул.");
 
     let query: string;
 

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -27,6 +27,14 @@ const OVERPASS_DELAY_MS = 500; // 500ms for Overpass API (generous limits)
 const OVERPASS_TIMEOUT_MS = 25000; // 25 seconds timeout for HTTP requests
 const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
+// In-memory cache for street geometry lookups (keyed on normalized street name)
+const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
+
+/** Clear the street geometry cache. Exported for test isolation. */
+export function clearStreetGeometryCache(): void {
+  streetGeometryCache.clear();
+}
+
 /**
  * Parse Overpass XML error response to extract error message
  */
@@ -128,6 +136,13 @@ async function getStreetGeometryFromOverpass(
   try {
     // Normalize street name for better OSM matching
     const normalizedName = normalizeStreetName(streetName);
+
+    // Return cached result if available (includes null for streets not found in OSM)
+    if (streetGeometryCache.has(normalizedName)) {
+      logger.info("Street geometry cache hit", { streetName, normalizedName });
+      return streetGeometryCache.get(normalizedName)!;
+    }
+
     const queryRegex = toOverpassRegex(normalizedName);
 
     // Check if this is a square/plaza (площад/пл.)
@@ -267,6 +282,7 @@ async function getStreetGeometryFromOverpass(
     if (!responseData.elements || responseData.elements.length === 0) {
       // No OSM ways found - API request succeeded but no data for this street name
       logger.info("Could not find street in OSM", { streetName });
+      streetGeometryCache.set(normalizedName, null);
       return null;
     }
 
@@ -309,6 +325,7 @@ async function getStreetGeometryFromOverpass(
 
     if (lineStrings.length === 0) {
       logger.info("No valid geometries in response", { streetName });
+      streetGeometryCache.set(normalizedName, null);
       return null;
     }
 
@@ -327,6 +344,7 @@ async function getStreetGeometryFromOverpass(
       },
     };
 
+    streetGeometryCache.set(normalizedName, multiLineString);
     return multiLineString;
   } catch (error) {
     logger.error("Error fetching from Overpass", {


### PR DESCRIPTION
## Summary

Add a module-level `Map<string, Feature<MultiLineString> | null>` cache to `getStreetGeometryFromOverpass()`, keyed on the normalized street name. This deduplicates Overpass HTTP calls when the same street appears in multiple intersections or address lookups within a single ingest run.

## Problem

If "ул. Example" appears in 3 intersections, the function fetches its geometry from Overpass 3 separate times, each incurring a 500ms rate-limit delay. See #332 for details.

## Changes

**`ingest/geocoding/overpass/service.ts`**
- Added `streetGeometryCache` Map at module level, keyed on normalized street name (output of `normalizeStreetName()`)
- `getStreetGeometryFromOverpass()` checks cache before making HTTP requests and populates it on all return paths
- `null` results are cached too — avoids re-fetching streets OSM doesn't know about
- Cache hits are logged for observability
- Exported `clearStreetGeometryCache()` for test isolation

**`ingest/geocoding/overpass/service.test.ts`**
- Added tests for `clearStreetGeometryCache()`

## Design decisions

- **Cache key:** `normalizedName` (canonical form already computed for every call)
- **Cache nulls:** yes — prevents re-querying streets that don't exist in OSM
- **No TTL:** cache lives only for process lifetime (single ingest run), so stale data isn't a concern
- **Pattern:** follows existing `boundaryCache` in `ingest/geocoding/shared/boundary-utils.ts`

Closes #332