### PR TITLE
feat: persist geocoding progress incrementally to survive script interruption

### DIFF
--- a/docs/features/geocode-cache.md
+++ b/docs/features/geocode-cache.md
@@ -29,9 +29,35 @@ flowchart TD
 3. **Pre-cache via CLI** — for each high-frequency uncached entry, run the `geocode-cache:add` script pointing at a message that already has valid geometry for that address.
 4. **Automatic pickup** — the next ingestion run loads the new cache entries and skips API calls for those locations.
 
+## Geocoding Progress
+
+Geocoding calls external APIs and can take several minutes for messages with many locations. To avoid losing work if the ingestion process is interrupted, results are persisted to the database incrementally as they arrive. This means partial geocoding results are available in the admin page immediately — without waiting for a full ingestion run to complete.
+
+When a run finishes successfully, the incremental entries are consolidated into a single final record for that message. If the run is interrupted, the partial entries remain and are still visible in the admin page geometry panel, so they can be promoted to the persistent cache right away.
+
+## Recovery After Interrupted Runs
+
+```mermaid
+flowchart TD
+    Crash([Run interrupted]) --> DB[(Partial geocoding results persisted)]
+    DB --> Page[Admin opens /geocode-cache page]
+    Page --> Freq[Generate/refresh frequency report]
+    Freq --> Review[Review uncached entries\nand verify geometry in panel]
+    Review --> CLI[Run geocode-cache:add for each entry]
+    CLI --> Cache[(Persistent cache populated)]
+    Cache --> NextRun([Next ingestion run uses cache ✓])
+```
+
+1. Open the `/geocode-cache` page and generate a fresh frequency report if needed.
+2. For each address or street that appears uncached, open the geometry panel and verify the geometry looks correct.
+3. Copy the `geocode-cache:add` command from the panel and run it.
+4. On the next ingestion run, those addresses will be served from cache.
+
+The interrupted message itself still needs to be re-ingested to produce a finalized result. This workflow is specifically about preserving the expensive API results so re-ingestion is cheap.
+
 ## Scheduling
 
-The frequency report is generated automatically on a recurring weekly schedule via the cloud scheduler/job pipeline. The exact timing is configurable per environment; check the current infrastructure configuration for the active schedule if verification is needed.
+The frequency report is generated automatically on a weekly schedule. The exact timing is configurable per environment.
 
 ## CLI Scripts
 
@@ -41,14 +67,12 @@ Both scripts run from the `ingest/` directory:
 # Generate + upload frequency report to GCS
 pnpm geocode-cache:report
 
-# Pre-cache a single address from an existing message
+# Pre-cache a pin or street geometry from an existing message
 pnpm geocode-cache:add -- --message <id> --address "ул. Граф Игнатиев 10" --type pin
-
-# Pre-cache a street geometry from an existing message
 pnpm geocode-cache:add -- --message <id> --address "бул. Витоша" --type street
 ```
 
-The frequency report script supports `--dry-run` to print the top uncached pins and streets to stdout without uploading to GCS.
+The frequency report script supports `--dry-run` to print results to stdout without uploading to GCS.
 
 ## Admin Page
 
@@ -56,11 +80,10 @@ The `/geocode-cache` page (linked from `/sources`) provides:
 
 - **Frequency tables** for pins and streets — entries appearing more than once, sorted by count
 - **Filters** — toggle between top 50 / all entries, and filter to uncached-only
-- **Geometry visualization** — clicking an entry opens a side panel with a Google Map showing color-coded markers (pins) or polylines (streets) from the source messages
-- **Copy command** — each message row has a button that copies the `geocode-cache:add` CLI command to the clipboard
+- **Geometry visualization** — clicking an entry opens a side panel with a map showing markers (pins) or polylines (streets) from source messages. Partial results from interrupted runs appear here as soon as they are persisted.
+- **Copy command** — each message row has a button that copies the ready-to-run `geocode-cache:add` command to the clipboard
 
 ## Related
 
 - [Geocoding](../../ingest/geocoding/README.md) — routing, services, and rate limits
 - [Message Ingest Pipeline](../../ingest/messageIngest/README.md) — where geocoding fits in the pipeline
-- [Air Quality Storage](air-quality-storage.md) — uses the same `GCS_GENERIC_BUCKET` for file storage

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -18,6 +18,7 @@ import { logger } from "@/lib/logger";
 import { isWithinBounds } from "@oboapp/shared";
 import { getLocality } from "@/lib/target-locality";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
+import type { GeocodingProgressTracker } from "./geocoding-progress-tracker";
 
 // Internal types for the geocoding pipeline
 export interface GeocodingResult {
@@ -210,8 +211,11 @@ async function geocodePins(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
   addresses: Address[],
+  tracker?: GeocodingProgressTracker,
 ): Promise<void> {
   if (extractedData.pins.length === 0) return;
+
+  const countBefore = addresses.length;
 
   const pinsToGeocode = processPinsWithPreResolvedCoordinates(
     extractedData.pins,
@@ -226,6 +230,12 @@ async function geocodePins(
     geocodedPins.forEach((addr) => {
       preGeocodedMap.set(addr.originalText, addr.coordinates);
     });
+  }
+
+  if (tracker) {
+    // Record all resolved pins (pre-resolved + API-geocoded) with the full input count as attempted
+    const resolvedPins = addresses.slice(countBefore);
+    await tracker.recordPins(resolvedPins, extractedData.pins.length);
   }
 }
 
@@ -432,6 +442,7 @@ async function geocodeEducationalFacilitiesFromExtractedData(
 export async function geocodeAddressesFromExtractedData(
   extractedData: ExtractedLocations | null,
   ingestErrors?: IngestErrorRecorder,
+  tracker?: GeocodingProgressTracker,
 ): Promise<GeocodingResult> {
   const preGeocodedMap = new Map<string, Coordinates>();
   const addresses: Address[] = [];
@@ -445,20 +456,23 @@ export async function geocodeAddressesFromExtractedData(
   await seedStreetCacheFromDb();
 
   // Geocode each location type using specialized services
-  await geocodePins(extractedData, preGeocodedMap, addresses);
+  await geocodePins(extractedData, preGeocodedMap, addresses, tracker);
   await geocodeStreetIntersections(extractedData, preGeocodedMap, addresses);
   const cadastralGeometries = await geocodeCadastralProperties(extractedData);
+  tracker?.recordAttempted(extractedData.cadastralProperties?.length ?? 0);
   await geocodeBusStopsFromExtractedData(
     extractedData,
     preGeocodedMap,
     addresses,
   );
+  tracker?.recordAttempted(extractedData.busStops?.length ?? 0);
   await geocodeEducationalFacilitiesFromExtractedData(
     extractedData,
     preGeocodedMap,
     addresses,
     ingestErrors,
   );
+  tracker?.recordAttempted(extractedData.educationalFacilities?.length ?? 0);
 
   // Deduplicate addresses before returning
   const deduplicatedAddresses = deduplicateAddresses(addresses);

--- a/ingest/messageIngest/geocoding-progress-tracker.test.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Address } from "@/lib/types";
+
+// Must mock firebase-admin before any module that transitively imports it
+vi.mock("@/lib/firebase-admin", () => ({
+  adminDb: vi.fn(),
+}));
+
+const mockUpdateMessage = vi.fn();
+vi.mock("./db/update-message", () => ({
+  updateMessage: (...args: unknown[]) => mockUpdateMessage(...args),
+}));
+
+const mockFindById = vi.fn();
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn().mockResolvedValue({
+    messages: {
+      findById: (...args: unknown[]) => mockFindById(...args),
+    },
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { createGeocodingProgressTracker } from "./geocoding-progress-tracker";
+
+// ---------------------------------------------------------------------------
+// Types and helpers
+// ---------------------------------------------------------------------------
+
+type ProcessStep = Record<string, unknown>;
+type UpdateOp =
+  | { $addToSet: { process: ProcessStep } }
+  | { $set: { process: ProcessStep[] } };
+
+/** All calls to updateMessage as typed tuples. */
+function updateCalls(): Array<[string, UpdateOp]> {
+  return mockUpdateMessage.mock.calls as Array<[string, UpdateOp]>;
+}
+
+/** Calls that wrote a geocodingBatch step ($addToSet). */
+function batchWrites() {
+  return updateCalls()
+    .filter((c): c is [string, { $addToSet: { process: ProcessStep } }] =>
+      "$addToSet" in c[1],
+    )
+    .map(([, u]) => u.$addToSet.process);
+}
+
+/** Calls that wrote a final geocoding step ($set). */
+function finalWrites() {
+  return updateCalls()
+    .filter((c): c is [string, { $set: { process: ProcessStep[] } }] =>
+      "$set" in c[1],
+    )
+    .map(([, u]) => u.$set.process);
+}
+
+function makeAddress(text: string): Address {
+  return {
+    originalText: text,
+    formattedAddress: `${text}, Sofia`,
+    coordinates: { lat: 42.7, lng: 23.3 },
+    geoJson: { type: "Point", coordinates: [23.3, 42.7] },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateMessage.mockResolvedValue(undefined);
+});
+
+
+describe("createGeocodingProgressTracker", () => {
+  describe("recordPins batching", () => {
+    it("does not flush when pending count is below BATCH_SIZE", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 20);
+      // 9 pins — below the 10-item threshold
+      await tracker.recordPins(
+        Array.from({ length: 9 }, (_, i) => makeAddress(`Addr ${i}`)),
+        9,
+      );
+      expect(mockUpdateMessage).not.toHaveBeenCalled();
+    });
+
+    it("flushes exactly when pending count reaches BATCH_SIZE", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 20);
+      // 10 pins — meets threshold inside the loop
+      await tracker.recordPins(
+        Array.from({ length: 10 }, (_, i) => makeAddress(`Addr ${i}`)),
+        10,
+      );
+      expect(batchWrites()).toHaveLength(1);
+      expect(batchWrites()[0]["pins"]).toHaveLength(10);
+      expect(batchWrites()[0]["step"]).toBe("geocodingBatch");
+    });
+
+    it("flushes multiple times when more than BATCH_SIZE pins are added", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 25);
+      await tracker.recordPins(
+        Array.from({ length: 22 }, (_, i) => makeAddress(`Addr ${i}`)),
+        22,
+      );
+      // Should flush at 10 and again at 20; 2 remaining stay pending
+      expect(batchWrites()).toHaveLength(2);
+    });
+  });
+
+  describe("recordStreet batching", () => {
+    it("flushes after 10 mixed pins+streets", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 20);
+      await tracker.recordPins(
+        Array.from({ length: 8 }, (_, i) => makeAddress(`Addr ${i}`)),
+        8,
+      );
+      expect(batchWrites()).toHaveLength(0);
+
+      // Adding 2 streets should push past BATCH_SIZE
+      await tracker.recordStreet({
+        key: "street-1",
+        originalName: "Main St",
+        geometry: '{"type":"Feature"}',
+      });
+      await tracker.recordStreet({
+        key: "street-2",
+        originalName: "Side St",
+        geometry: '{"type":"Feature"}',
+      });
+
+      expect(batchWrites()).toHaveLength(1);
+    });
+  });
+
+  describe("flush failure recovery", () => {
+    it("retains pending items when the DB write fails so they can be flushed later", async () => {
+      mockUpdateMessage.mockRejectedValueOnce(new Error("network error"));
+
+      const tracker = createGeocodingProgressTracker("msg1", 20);
+      const pins = Array.from({ length: 10 }, (_, i) => makeAddress(`Addr ${i}`));
+
+      await expect(tracker.recordPins(pins, 10)).rejects.toThrow("network error");
+
+      // After failure, fix the mock and finalize — the failed items should still appear
+      mockFindById.mockResolvedValue({ process: [] });
+      mockUpdateMessage.mockResolvedValue(undefined);
+
+      await tracker.finalize();
+
+      const writes = finalWrites();
+      expect(writes).toHaveLength(1);
+      const geocodingStep = writes[0].find((s) => s["step"] === "geocoding");
+      expect(geocodingStep?.["pins"]).toHaveLength(10);
+    });
+  });
+
+  describe("finalize()", () => {
+    it("replaces geocodingBatch entries for the run with a single geocoding step", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 5);
+
+      mockFindById.mockResolvedValue({
+        process: [
+          { step: "filterAndSplit" },
+          { step: "geocodingBatch", runId: "other-run", pins: [], streets: [] },
+        ],
+      });
+
+      await tracker.recordPins([makeAddress("Addr 1")], 1);
+      await tracker.finalize();
+
+      const writes = finalWrites();
+      expect(writes).toHaveLength(1);
+      const process = writes[0];
+      expect(process.filter((s) => s["step"] === "filterAndSplit")).toHaveLength(1);
+      expect(
+        process.filter(
+          (s) => s["step"] === "geocodingBatch" && s["runId"] === "other-run",
+        ),
+      ).toHaveLength(1);
+      expect(process.filter((s) => s["step"] === "geocoding")).toHaveLength(1);
+    });
+
+    it("does not write a geocoding step when no pins or streets were resolved", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 3);
+      tracker.recordAttempted(3);
+      await tracker.finalize();
+
+      expect(mockFindById).not.toHaveBeenCalled();
+      expect(finalWrites()).toHaveLength(0);
+    });
+
+    it("flushes any remaining pending items before finalizing", async () => {
+      mockFindById.mockResolvedValue({ process: [] });
+
+      const tracker = createGeocodingProgressTracker("msg1", 5);
+      // 3 pins — below flush threshold, should be captured by finalize's final flush
+      await tracker.recordPins(
+        [makeAddress("A"), makeAddress("B"), makeAddress("C")],
+        3,
+      );
+      expect(batchWrites()).toHaveLength(0);
+
+      await tracker.finalize();
+
+      const writes = finalWrites();
+      expect(writes).toHaveLength(1);
+      const geocodingStep = writes[0].find((s) => s["step"] === "geocoding");
+      expect(geocodingStep?.["pins"]).toHaveLength(3);
+    });
+
+    it("strips own geocodingBatch entries and keeps unrelated process steps", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 12);
+
+      // Flush 10 items to get a geocodingBatch entry committed
+      await tracker.recordPins(
+        Array.from({ length: 10 }, (_, i) => makeAddress(`Addr ${i}`)),
+        10,
+      );
+      expect(batchWrites()).toHaveLength(1);
+      const runId = batchWrites()[0]["runId"] as string;
+
+      // Simulate DB state: the batch entry plus unrelated steps
+      mockFindById.mockResolvedValue({
+        process: [
+          { step: "categorize" },
+          { step: "geocodingBatch", runId, pins: [], streets: [] },
+        ],
+      });
+
+      await tracker.recordPins(
+        [makeAddress("Addr 10"), makeAddress("Addr 11")],
+        2,
+      );
+      await tracker.finalize();
+
+      const writes = finalWrites();
+      const steps = writes[0].map((s) => s["step"]);
+      expect(steps).toContain("categorize");
+      expect(steps).not.toContain("geocodingBatch");
+      expect(steps).toContain("geocoding");
+    });
+  });
+
+  describe("progress tracking", () => {
+    it("accumulates done count across recordPins, recordStreet, and recordAttempted", async () => {
+      mockFindById.mockResolvedValue({ process: [] });
+      const tracker = createGeocodingProgressTracker("msg1", 10);
+
+      await tracker.recordPins([makeAddress("A"), makeAddress("B")], 3); // done += 3
+      await tracker.recordStreet({
+        key: "s1",
+        originalName: "Main St",
+        geometry: "{}",
+      }); // done += 1
+      tracker.recordAttempted(4); // done += 4
+      await tracker.finalize();
+
+      const writes = finalWrites();
+      const geocodingStep = writes[0].find((s) => s["step"] === "geocoding");
+      const progress = geocodingStep?.["progress"] as {
+        done: number;
+        toDo: number;
+      };
+      expect(progress.done).toBe(8);
+      expect(progress.toDo).toBe(10);
+    });
+  });
+});

--- a/ingest/messageIngest/geocoding-progress-tracker.test.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.test.ts
@@ -43,8 +43,9 @@ function updateCalls(): Array<[string, UpdateOp]> {
 /** Calls that wrote a geocodingBatch step ($addToSet). */
 function batchWrites() {
   return updateCalls()
-    .filter((c): c is [string, { $addToSet: { process: ProcessStep } }] =>
-      "$addToSet" in c[1],
+    .filter(
+      (c): c is [string, { $addToSet: { process: ProcessStep } }] =>
+        "$addToSet" in c[1],
     )
     .map(([, u]) => u.$addToSet.process);
 }
@@ -52,8 +53,9 @@ function batchWrites() {
 /** Calls that wrote a final geocoding step ($set). */
 function finalWrites() {
   return updateCalls()
-    .filter((c): c is [string, { $set: { process: ProcessStep[] } }] =>
-      "$set" in c[1],
+    .filter(
+      (c): c is [string, { $set: { process: ProcessStep[] } }] =>
+        "$set" in c[1],
     )
     .map(([, u]) => u.$set.process);
 }
@@ -71,7 +73,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockUpdateMessage.mockResolvedValue(undefined);
 });
-
 
 describe("createGeocodingProgressTracker", () => {
   describe("recordPins batching", () => {
@@ -138,9 +139,13 @@ describe("createGeocodingProgressTracker", () => {
       mockUpdateMessage.mockRejectedValueOnce(new Error("network error"));
 
       const tracker = createGeocodingProgressTracker("msg1", 20);
-      const pins = Array.from({ length: 10 }, (_, i) => makeAddress(`Addr ${i}`));
+      const pins = Array.from({ length: 10 }, (_, i) =>
+        makeAddress(`Addr ${i}`),
+      );
 
-      await expect(tracker.recordPins(pins, 10)).rejects.toThrow("network error");
+      await expect(tracker.recordPins(pins, 10)).rejects.toThrow(
+        "network error",
+      );
 
       // After failure, fix the mock and finalize — the failed items should still appear
       mockFindById.mockResolvedValue({ process: [] });
@@ -172,7 +177,9 @@ describe("createGeocodingProgressTracker", () => {
       const writes = finalWrites();
       expect(writes).toHaveLength(1);
       const process = writes[0];
-      expect(process.filter((s) => s["step"] === "filterAndSplit")).toHaveLength(1);
+      expect(
+        process.filter((s) => s["step"] === "filterAndSplit"),
+      ).toHaveLength(1);
       expect(
         process.filter(
           (s) => s["step"] === "geocodingBatch" && s["runId"] === "other-run",

--- a/ingest/messageIngest/geocoding-progress-tracker.test.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.test.ts
@@ -249,6 +249,47 @@ describe("createGeocodingProgressTracker", () => {
     });
   });
 
+  describe("flushPending()", () => {
+    it("flushes pending items to geocodingBatch without writing a geocoding step", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 5);
+      await tracker.recordPins(
+        [makeAddress("A"), makeAddress("B"), makeAddress("C")],
+        3,
+      );
+      // Below BATCH_SIZE — no auto-flush yet
+      expect(batchWrites()).toHaveLength(0);
+
+      await tracker.flushPending();
+
+      expect(batchWrites()).toHaveLength(1);
+      expect(batchWrites()[0]["step"]).toBe("geocodingBatch");
+      expect(batchWrites()[0]["pins"]).toHaveLength(3);
+      // No consolidation — findById and $set must not have been called
+      expect(mockFindById).not.toHaveBeenCalled();
+      expect(finalWrites()).toHaveLength(0);
+    });
+
+    it("is a no-op when there are no pending items", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 5);
+      await tracker.flushPending();
+      expect(mockUpdateMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not flush already-flushed items again", async () => {
+      const tracker = createGeocodingProgressTracker("msg1", 15);
+      // Trigger an auto-flush at BATCH_SIZE
+      await tracker.recordPins(
+        Array.from({ length: 10 }, (_, i) => makeAddress(`Addr ${i}`)),
+        10,
+      );
+      expect(batchWrites()).toHaveLength(1);
+
+      // flushPending should only flush the remaining 0 pending items (none left)
+      await tracker.flushPending();
+      expect(batchWrites()).toHaveLength(1);
+    });
+  });
+
   describe("progress tracking", () => {
     it("accumulates done count across recordPins, recordStreet, and recordAttempted", async () => {
       mockFindById.mockResolvedValue({ process: [] });

--- a/ingest/messageIngest/geocoding-progress-tracker.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.ts
@@ -136,7 +136,12 @@ export function createGeocodingProgressTracker(
 
       const rawProcess = Array.isArray(msg.process) ? msg.process : [];
       const withoutBatches = rawProcess.filter(
-        (s) => !(isRecord(s) && s["step"] === "geocodingBatch" && s["runId"] === runId),
+        (s) =>
+          !(
+            isRecord(s) &&
+            s["step"] === "geocodingBatch" &&
+            s["runId"] === runId
+          ),
       );
 
       withoutBatches.push({

--- a/ingest/messageIngest/geocoding-progress-tracker.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import type { Address } from "@/lib/types";
+import { normalizePinAddress } from "@oboapp/shared";
+import { updateMessage } from "./db/update-message";
+import { getDb } from "@/lib/db";
+import { isRecord } from "@/lib/record-fields";
+
+const BATCH_SIZE = 10;
+
+export interface GeocodingPinEntry {
+  key: string;
+  originalText: string;
+  formattedAddress: string;
+  coordinates: { lat: number; lng: number };
+  geoJson?: { type: "Point"; coordinates: [number, number] };
+}
+
+export interface GeocodingStreetEntry {
+  key: string;
+  originalName: string;
+  /** JSON-stringified Feature<MultiLineString> */
+  geometry: string;
+}
+
+export interface GeocodingProgressTracker {
+  /**
+   * Record resolved pins. `attempted` should equal the total number of pin inputs
+   * (including pre-resolved ones), so the progress counter stays in sync with `toDo`.
+   */
+  recordPins(geocoded: Address[], attempted: number): Promise<void>;
+  /**
+   * Record a single resolved street geometry. Increments `done` by 1.
+   * Call for every street regardless of whether a geometry was found — use
+   * `recordAttempted(1)` when no geometry was resolved.
+   */
+  recordStreet(entry: GeocodingStreetEntry): Promise<void>;
+  /**
+   * Increment `done` without storing a result. Use for:
+   * - Streets with no resolved geometry (pass 1)
+   * - Cadastral properties, bus stops, educational facilities (pass input count)
+   */
+  recordAttempted(count: number): void;
+  /**
+   * Flush any remaining pending items, then replace all intermediate `geocodingBatch`
+   * entries for this run with a single final `geocoding` step in `process[]`.
+   * If no pins or streets were resolved, batch entries are flushed but no final
+   * `geocoding` step is written (the DB read-modify-write is skipped).
+   */
+  finalize(): Promise<void>;
+}
+
+export function createGeocodingProgressTracker(
+  messageId: string,
+  toDo: number,
+): GeocodingProgressTracker {
+  const runId = randomUUID();
+  const allPins: GeocodingPinEntry[] = [];
+  const allStreets: GeocodingStreetEntry[] = [];
+  const pendingPins: GeocodingPinEntry[] = [];
+  const pendingStreets: GeocodingStreetEntry[] = [];
+  let done = 0;
+
+  function addressToPinEntry(addr: Address): GeocodingPinEntry {
+    const entry: GeocodingPinEntry = {
+      key: normalizePinAddress(addr.originalText),
+      originalText: addr.originalText,
+      formattedAddress: addr.formattedAddress,
+      coordinates: addr.coordinates,
+    };
+    if (addr.geoJson) {
+      entry.geoJson = addr.geoJson;
+    }
+    return entry;
+  }
+
+  async function flush(): Promise<void> {
+    if (pendingPins.length === 0 && pendingStreets.length === 0) return;
+
+    const batch = {
+      step: "geocodingBatch",
+      runId,
+      timestamp: new Date().toISOString(),
+      progress: { toDo, done },
+      pins: [...pendingPins],
+      streets: [...pendingStreets],
+    };
+
+    // Clear pending before the async write to avoid double-writes if an error is thrown
+    pendingPins.length = 0;
+    pendingStreets.length = 0;
+
+    await updateMessage(messageId, {
+      $addToSet: { process: batch },
+    });
+  }
+
+  async function maybeFlush(): Promise<void> {
+    if (pendingPins.length + pendingStreets.length >= BATCH_SIZE) {
+      await flush();
+    }
+  }
+
+  return {
+    async recordPins(geocoded: Address[], attempted: number): Promise<void> {
+      for (const addr of geocoded) {
+        const entry = addressToPinEntry(addr);
+        allPins.push(entry);
+        pendingPins.push(entry);
+      }
+      done += attempted;
+      await maybeFlush();
+    },
+
+    async recordStreet(entry: GeocodingStreetEntry): Promise<void> {
+      allStreets.push(entry);
+      pendingStreets.push(entry);
+      done += 1;
+      await maybeFlush();
+    },
+
+    recordAttempted(count: number): void {
+      done += count;
+    },
+
+    async finalize(): Promise<void> {
+      await flush();
+
+      if (allPins.length === 0 && allStreets.length === 0) return;
+
+      const db = await getDb();
+      const msg = await db.messages.findById(messageId);
+      if (!msg) return;
+
+      const rawProcess = Array.isArray(msg.process) ? msg.process : [];
+      const withoutBatches = rawProcess.filter(
+        (s) => !(isRecord(s) && s["step"] === "geocodingBatch" && s["runId"] === runId),
+      );
+
+      withoutBatches.push({
+        step: "geocoding",
+        runId,
+        timestamp: new Date().toISOString(),
+        progress: { toDo, done },
+        pins: allPins,
+        streets: allStreets,
+      });
+
+      await updateMessage(messageId, { $set: { process: withoutBatches } });
+    },
+  };
+}

--- a/ingest/messageIngest/geocoding-progress-tracker.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.ts
@@ -41,10 +41,16 @@ export interface GeocodingProgressTracker {
    */
   recordAttempted(count: number): void;
   /**
+   * Flush any remaining pending items to `geocodingBatch` without consolidating.
+   * Safe to call on both success and failure paths.
+   */
+  flushPending(): Promise<void>;
+  /**
    * Flush any remaining pending items, then replace all intermediate `geocodingBatch`
    * entries for this run with a single final `geocoding` step in `process[]`.
    * If no pins or streets were resolved, batch entries are flushed but no final
    * `geocoding` step is written (the DB read-modify-write is skipped).
+   * Should only be called on the success path.
    */
   finalize(): Promise<void>;
 }
@@ -123,6 +129,10 @@ export function createGeocodingProgressTracker(
 
     recordAttempted(count: number): void {
       done += count;
+    },
+
+    async flushPending(): Promise<void> {
+      await flush();
     },
 
     async finalize(): Promise<void> {

--- a/ingest/messageIngest/geocoding-progress-tracker.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.ts
@@ -76,22 +76,25 @@ export function createGeocodingProgressTracker(
   async function flush(): Promise<void> {
     if (pendingPins.length === 0 && pendingStreets.length === 0) return;
 
+    const pinsToFlush = [...pendingPins];
+    const streetsToFlush = [...pendingStreets];
+
     const batch = {
       step: "geocodingBatch",
       runId,
       timestamp: new Date().toISOString(),
       progress: { toDo, done },
-      pins: [...pendingPins],
-      streets: [...pendingStreets],
+      pins: pinsToFlush,
+      streets: streetsToFlush,
     };
-
-    // Clear pending before the async write to avoid double-writes if an error is thrown
-    pendingPins.length = 0;
-    pendingStreets.length = 0;
 
     await updateMessage(messageId, {
       $addToSet: { process: batch },
     });
+
+    // Only clear after the write succeeds so items can be retried on error
+    pendingPins.splice(0, pinsToFlush.length);
+    pendingStreets.splice(0, streetsToFlush.length);
   }
 
   async function maybeFlush(): Promise<void> {
@@ -106,9 +109,9 @@ export function createGeocodingProgressTracker(
         const entry = addressToPinEntry(addr);
         allPins.push(entry);
         pendingPins.push(entry);
+        await maybeFlush();
       }
       done += attempted;
-      await maybeFlush();
     },
 
     async recordStreet(entry: GeocodingStreetEntry): Promise<void> {

--- a/ingest/messageIngest/geocoding-progress-tracker.ts
+++ b/ingest/messageIngest/geocoding-progress-tracker.ts
@@ -105,13 +105,13 @@ export function createGeocodingProgressTracker(
 
   return {
     async recordPins(geocoded: Address[], attempted: number): Promise<void> {
+      done += attempted;
       for (const addr of geocoded) {
         const entry = addressToPinEntry(addr);
         allPins.push(entry);
         pendingPins.push(entry);
         await maybeFlush();
       }
-      done += attempted;
     },
 
     async recordStreet(entry: GeocodingStreetEntry): Promise<void> {

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -815,10 +815,16 @@ async function performGeocodingWithErrorHandling(
         }
       }
     } catch (streetError) {
-      logger.warn("Failed to record street geometries in progress tracker — geocoding result unaffected", {
-        messageId,
-        error: streetError instanceof Error ? streetError.message : String(streetError),
-      });
+      logger.warn(
+        "Failed to record street geometries in progress tracker — geocoding result unaffected",
+        {
+          messageId,
+          error:
+            streetError instanceof Error
+              ? streetError.message
+              : String(streetError),
+        },
+      );
     }
 
     return { addresses: filteredAddresses, geoJson };
@@ -831,10 +837,16 @@ async function performGeocodingWithErrorHandling(
     try {
       await tracker.finalize();
     } catch (finalizeError) {
-      logger.warn("Failed to finalize geocoding progress tracker — partial progress may be lost", {
-        messageId,
-        error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
-      });
+      logger.warn(
+        "Failed to finalize geocoding progress tracker — partial progress may be lost",
+        {
+          messageId,
+          error:
+            finalizeError instanceof Error
+              ? finalizeError.message
+              : String(finalizeError),
+        },
+      );
     }
   }
 }

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -16,6 +16,10 @@ import {
 } from "@/lib/ingest-errors";
 import { storeIncomingMessage, updateMessage } from "./db";
 import { encodeDocumentId } from "../crawlers/shared/firestore";
+import {
+  createGeocodingProgressTracker,
+  type GeocodingProgressTracker,
+} from "./geocoding-progress-tracker";
 import { logger } from "@/lib/logger";
 import { getLocality } from "@/lib/target-locality";
 import {
@@ -704,12 +708,14 @@ function ensureCrawledAtDate(crawledAt: Date | string | undefined): Date {
 async function performGeocoding(
   extractedLocations: ExtractedLocations,
   ingestErrors?: IngestErrorRecorder,
+  tracker?: GeocodingProgressTracker,
 ) {
   const { geocodeAddressesFromExtractedData } =
     await import("./geocode-addresses");
   return await geocodeAddressesFromExtractedData(
     extractedLocations,
     ingestErrors,
+    tracker,
   );
 }
 
@@ -724,10 +730,19 @@ async function performGeocodingWithErrorHandling(
   addresses: Address[];
   geoJson: GeoJSONFeatureCollection | null;
 } | null> {
+  const toDo =
+    (extractedLocations.pins?.length ?? 0) +
+    (extractedLocations.streets?.length ?? 0) +
+    (extractedLocations.cadastralProperties?.length ?? 0) +
+    (extractedLocations.busStops?.length ?? 0) +
+    (extractedLocations.educationalFacilities?.length ?? 0);
+  const tracker = createGeocodingProgressTracker(messageId, toDo);
+
   try {
     const geocodingResult = await performGeocoding(
       extractedLocations,
       ingestErrors,
+      tracker,
     );
     const filteredAddresses = await filterAndStoreAddresses(
       messageId,
@@ -761,11 +776,11 @@ async function performGeocodingWithErrorHandling(
       geocodedEducationalFacilities,
     );
 
-    // Persist full street geometries to message.process for cache pre-population and reporting.
+    // Record street geometries into the progress tracker.
     // Reads from the in-memory cache populated during performGeocoding(). For streets geocoded via
     // geotagged coordinates (Overpass was skipped), we make an explicit Overpass fetch here so their
-    // geometry ends up in the cache too.
-    // Wrapped in its own try/catch so a failure here doesn't invalidate the geocoding result above.
+    // geometry ends up in the tracker too.
+    // Wrapped in its own try/catch so failures here don't invalidate the geocoding result above.
     try {
       if (extractedLocations.streets.length > 0) {
         const {
@@ -773,10 +788,8 @@ async function performGeocodingWithErrorHandling(
           getStreetGeometryFromOverpass,
           hasStreetGeometryQueried,
         } = await import("@/geocoding/overpass/service");
-        const { normalizePinAddress } =
-          await import("@oboapp/shared");
+        const { normalizePinAddress } = await import("@oboapp/shared");
         const { delay } = await import("@/lib/delay");
-        const streetGeometries = [];
         let overpassFetchCount = 0;
         for (const s of extractedLocations.streets) {
           let geometry = getStreetGeometryCached(s.street);
@@ -790,31 +803,21 @@ async function performGeocodingWithErrorHandling(
             overpassFetchCount++;
           }
           if (geometry) {
-            streetGeometries.push({
+            await tracker.recordStreet({
               key: normalizePinAddress(s.street),
               originalName: s.street,
               // Stringify to avoid Firestore nested-array rejection (coordinates: number[][][])
               geometry: JSON.stringify(geometry),
             });
+          } else {
+            tracker.recordAttempted(1);
           }
         }
-        if (streetGeometries.length > 0) {
-          await updateMessage(messageId, {
-            $addToSet: {
-              process: {
-                step: "streetGeometries",
-                timestamp: new Date().toISOString(),
-                result: streetGeometries,
-              },
-            },
-          });
-        }
       }
-    } catch (geometryError) {
-      const { logger } = await import("@/lib/logger");
-      logger.warn("Failed to persist street geometries to message.process — geocoding result unaffected", {
+    } catch (streetError) {
+      logger.warn("Failed to record street geometries in progress tracker — geocoding result unaffected", {
         messageId,
-        error: geometryError instanceof Error ? geometryError.message : String(geometryError),
+        error: streetError instanceof Error ? streetError.message : String(streetError),
       });
     }
 
@@ -824,6 +827,15 @@ async function performGeocodingWithErrorHandling(
     ingestErrors.exception(`Ingestion exception: ${errorMessage}`);
     await finalizeMessageWithoutGeoJson(messageId, ingestErrors);
     return null;
+  } finally {
+    try {
+      await tracker.finalize();
+    } catch (finalizeError) {
+      logger.warn("Failed to finalize geocoding progress tracker — partial progress may be lost", {
+        messageId,
+        error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
+      });
+    }
   }
 }
 

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -836,21 +836,23 @@ async function performGeocodingWithErrorHandling(
     await finalizeMessageWithoutGeoJson(messageId, ingestErrors);
     return null;
   } finally {
-    if (geocodingSucceeded) {
-      try {
+    try {
+      if (geocodingSucceeded) {
         await tracker.finalize();
-      } catch (finalizeError) {
-        logger.warn(
-          "Failed to finalize geocoding progress tracker — partial progress may be lost",
-          {
-            messageId,
-            error:
-              finalizeError instanceof Error
-                ? finalizeError.message
-                : String(finalizeError),
-          },
-        );
+      } else {
+        await tracker.flushPending();
       }
+    } catch (finalizeError) {
+      logger.warn(
+        "Failed to finalize geocoding progress tracker — partial progress may be lost",
+        {
+          messageId,
+          error:
+            finalizeError instanceof Error
+              ? finalizeError.message
+              : String(finalizeError),
+        },
+      );
     }
   }
 }

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -737,6 +737,7 @@ async function performGeocodingWithErrorHandling(
     (extractedLocations.busStops?.length ?? 0) +
     (extractedLocations.educationalFacilities?.length ?? 0);
   const tracker = createGeocodingProgressTracker(messageId, toDo);
+  let geocodingSucceeded = false;
 
   try {
     const geocodingResult = await performGeocoding(
@@ -827,6 +828,7 @@ async function performGeocodingWithErrorHandling(
       );
     }
 
+    geocodingSucceeded = true;
     return { addresses: filteredAddresses, geoJson };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -834,19 +836,21 @@ async function performGeocodingWithErrorHandling(
     await finalizeMessageWithoutGeoJson(messageId, ingestErrors);
     return null;
   } finally {
-    try {
-      await tracker.finalize();
-    } catch (finalizeError) {
-      logger.warn(
-        "Failed to finalize geocoding progress tracker — partial progress may be lost",
-        {
-          messageId,
-          error:
-            finalizeError instanceof Error
-              ? finalizeError.message
-              : String(finalizeError),
-        },
-      );
+    if (geocodingSucceeded) {
+      try {
+        await tracker.finalize();
+      } catch (finalizeError) {
+        logger.warn(
+          "Failed to finalize geocoding progress tracker — partial progress may be lost",
+          {
+            messageId,
+            error:
+              finalizeError instanceof Error
+                ? finalizeError.message
+                : String(finalizeError),
+          },
+        );
+      }
     }
   }
 }

--- a/ingest/scripts/geocode-cache-add.ts
+++ b/ingest/scripts/geocode-cache-add.ts
@@ -88,20 +88,47 @@ function extractGeocodingData(msg: Record<string, unknown>): {
     (s): s is Record<string, unknown> & { runId: string } =>
       s["step"] === "geocodingBatch" && typeof s["runId"] === "string",
   );
-  if (batchSteps.length === 0) return { pins: [], streets: [] };
+  if (batchSteps.length > 0) {
+    const lastRunId = batchSteps[batchSteps.length - 1].runId;
+    const batchesForRun = batchSteps.filter((s) => s["runId"] === lastRunId);
+    return {
+      pins: batchesForRun.flatMap((s) =>
+        Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
+      ),
+      streets: batchesForRun.flatMap((s) =>
+        Array.isArray(s["streets"])
+          ? s["streets"].filter(isGeocodingStreetEntry)
+          : [],
+      ),
+    };
+  }
 
-  const lastRunId = batchSteps[batchSteps.length - 1].runId;
-  const batchesForRun = batchSteps.filter((s) => s["runId"] === lastRunId);
-  return {
-    pins: batchesForRun.flatMap((s) =>
-      Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
-    ),
-    streets: batchesForRun.flatMap((s) =>
-      Array.isArray(s["streets"])
-        ? s["streets"].filter(isGeocodingStreetEntry)
-        : [],
-    ),
-  };
+  // Legacy fallback: read street geometries from the old streetGeometries process step
+  // (messages ingested before the geocoding step was introduced)
+  const legacySteps = steps.filter((s) => s["step"] === "streetGeometries");
+  if (legacySteps.length > 0) {
+    const last = legacySteps[legacySteps.length - 1];
+    const rawGeometries = Array.isArray(last["result"]) ? last["result"] : [];
+    const legacyStreets: GeocodingStreetEntry[] = rawGeometries
+      .filter(
+        (g): g is Record<string, unknown> =>
+          isRecord(g) &&
+          typeof g["key"] === "string" &&
+          typeof g["originalName"] === "string" &&
+          (typeof g["geometry"] === "string" || isRecord(g["geometry"])),
+      )
+      .map((g) => ({
+        key: g["key"] as string,
+        originalName: g["originalName"] as string,
+        geometry:
+          typeof g["geometry"] === "string"
+            ? (g["geometry"] as string)
+            : JSON.stringify(g["geometry"]),
+      }));
+    return { pins: [], streets: legacyStreets };
+  }
+
+  return { pins: [], streets: [] };
 }
 
 async function cachePin(

--- a/ingest/scripts/geocode-cache-add.ts
+++ b/ingest/scripts/geocode-cache-add.ts
@@ -29,6 +29,23 @@ import type {
 } from "@/messageIngest/geocoding-progress-tracker";
 import { isRecord } from "@/lib/record-fields";
 
+function isGeocodingPinEntry(v: unknown): v is GeocodingPinEntry {
+  return (
+    isRecord(v) &&
+    typeof v["key"] === "string" &&
+    typeof v["originalText"] === "string" &&
+    typeof v["formattedAddress"] === "string"
+  );
+}
+
+function isGeocodingStreetEntry(v: unknown): v is GeocodingStreetEntry {
+  return (
+    isRecord(v) &&
+    typeof v["key"] === "string" &&
+    typeof v["geometry"] === "string"
+  );
+}
+
 dotenv.config({ path: resolve(process.cwd(), ".env.local") });
 
 /**
@@ -53,8 +70,8 @@ function extractGeocodingData(msg: Record<string, unknown>): {
   if (geocodingSteps.length > 0) {
     const last = geocodingSteps[geocodingSteps.length - 1];
     return {
-      pins: (Array.isArray(last["pins"]) ? last["pins"] : []) as GeocodingPinEntry[],
-      streets: (Array.isArray(last["streets"]) ? last["streets"] : []) as GeocodingStreetEntry[],
+      pins: Array.isArray(last["pins"]) ? last["pins"].filter(isGeocodingPinEntry) : [],
+      streets: Array.isArray(last["streets"]) ? last["streets"].filter(isGeocodingStreetEntry) : [],
     };
   }
 
@@ -68,11 +85,11 @@ function extractGeocodingData(msg: Record<string, unknown>): {
   const lastRunId = batchSteps[batchSteps.length - 1].runId;
   const batchesForRun = batchSteps.filter((s) => s["runId"] === lastRunId);
   return {
-    pins: batchesForRun.flatMap(
-      (s) => (Array.isArray(s["pins"]) ? s["pins"] : []) as GeocodingPinEntry[],
+    pins: batchesForRun.flatMap((s) =>
+      Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
     ),
-    streets: batchesForRun.flatMap(
-      (s) => (Array.isArray(s["streets"]) ? s["streets"] : []) as GeocodingStreetEntry[],
+    streets: batchesForRun.flatMap((s) =>
+      Array.isArray(s["streets"]) ? s["streets"].filter(isGeocodingStreetEntry) : [],
     ),
   };
 }

--- a/ingest/scripts/geocode-cache-add.ts
+++ b/ingest/scripts/geocode-cache-add.ts
@@ -34,7 +34,10 @@ function isGeocodingPinEntry(v: unknown): v is GeocodingPinEntry {
     isRecord(v) &&
     typeof v["key"] === "string" &&
     typeof v["originalText"] === "string" &&
-    typeof v["formattedAddress"] === "string"
+    typeof v["formattedAddress"] === "string" &&
+    isRecord(v["coordinates"]) &&
+    typeof v["coordinates"]["lat"] === "number" &&
+    typeof v["coordinates"]["lng"] === "number"
   );
 }
 
@@ -42,6 +45,7 @@ function isGeocodingStreetEntry(v: unknown): v is GeocodingStreetEntry {
   return (
     isRecord(v) &&
     typeof v["key"] === "string" &&
+    typeof v["originalName"] === "string" &&
     typeof v["geometry"] === "string"
   );
 }
@@ -70,8 +74,12 @@ function extractGeocodingData(msg: Record<string, unknown>): {
   if (geocodingSteps.length > 0) {
     const last = geocodingSteps[geocodingSteps.length - 1];
     return {
-      pins: Array.isArray(last["pins"]) ? last["pins"].filter(isGeocodingPinEntry) : [],
-      streets: Array.isArray(last["streets"]) ? last["streets"].filter(isGeocodingStreetEntry) : [],
+      pins: Array.isArray(last["pins"])
+        ? last["pins"].filter(isGeocodingPinEntry)
+        : [],
+      streets: Array.isArray(last["streets"])
+        ? last["streets"].filter(isGeocodingStreetEntry)
+        : [],
     };
   }
 
@@ -89,7 +97,9 @@ function extractGeocodingData(msg: Record<string, unknown>): {
       Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
     ),
     streets: batchesForRun.flatMap((s) =>
-      Array.isArray(s["streets"]) ? s["streets"].filter(isGeocodingStreetEntry) : [],
+      Array.isArray(s["streets"])
+        ? s["streets"].filter(isGeocodingStreetEntry)
+        : [],
     ),
   };
 }
@@ -151,9 +161,7 @@ async function cachePin(
           console.error(`   - "${a.originalText}" / "${a.formattedAddress}"`);
         }
       } else {
-        console.error(
-          `   Message has no geocoded data. Has it been ingested?`,
-        );
+        console.error(`   Message has no geocoded data. Has it been ingested?`);
       }
     }
     process.exitCode = 1;
@@ -241,7 +249,20 @@ async function cacheStreet(
 
   let geometry: Feature<MultiLineString>;
   try {
-    geometry = JSON.parse(storedEntry.geometry) as Feature<MultiLineString>;
+    const parsed: unknown = JSON.parse(storedEntry.geometry);
+    if (
+      !isRecord(parsed) ||
+      parsed["type"] !== "Feature" ||
+      !isRecord(parsed["geometry"]) ||
+      parsed["geometry"]["type"] !== "MultiLineString"
+    ) {
+      console.error(
+        `❌ Stored geometry for "${normalized}" is not a GeoJSON Feature<MultiLineString>. Check the data and try again.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    geometry = parsed as unknown as Feature<MultiLineString>;
   } catch {
     console.error(
       `❌ Invalid street geometry value in message.process for messageId "${messageId}" and key "${normalized}".`,

--- a/ingest/scripts/geocode-cache-add.ts
+++ b/ingest/scripts/geocode-cache-add.ts
@@ -2,17 +2,17 @@
 /**
  * Manually pre-cache a single geocoded location for a given message.
  *
- * Reads an existing geocoded address (pin) from a message document, or
- * reads the full street geometry stored in message.process during ingestion,
- * and stores the result in the geocode cache collection so future ingestion
- * runs skip the API call entirely.
+ * Reads geocoded data (pins and street geometries) from a message's
+ * process[] geocoding step (populated during ingestion), and stores the
+ * result in the geocode cache collection so future ingestion runs skip
+ * the API call entirely.
  *
  * Usage:
- *   # Cache a pin address (reads geometry from message.addresses[])
+ *   # Cache a pin address (reads from message.process[] geocoding step, falls back to message.addresses[])
  *   pnpm tsx ingest/scripts/geocode-cache-add.ts \
  *     --message <messageId> --address "ул. Граф Игнатиев 10" --type pin
  *
- *   # Cache a full street geometry (reads from message.process[].streetGeometries)
+ *   # Cache a full street geometry (reads from message.process[] geocoding step)
  *   pnpm tsx ingest/scripts/geocode-cache-add.ts \
  *     --message <messageId> --address "бул. Витоша" --type street
  */
@@ -23,8 +23,59 @@ import { resolve } from "node:path";
 import type { Feature, MultiLineString } from "geojson";
 import { normalizePinAddress } from "@oboapp/shared";
 import type { Address, StreetSection } from "@/lib/types";
+import type {
+  GeocodingPinEntry,
+  GeocodingStreetEntry,
+} from "@/messageIngest/geocoding-progress-tracker";
+import { isRecord } from "@/lib/record-fields";
 
 dotenv.config({ path: resolve(process.cwd(), ".env.local") });
+
+/**
+ * Extract geocoded pins and streets from a message's process[] array.
+ * Prefers the final `geocoding` step. For interrupted runs (no `geocoding` step),
+ * falls back to merging all `geocodingBatch` entries for the most recent runId.
+ */
+function extractGeocodingData(msg: Record<string, unknown>): {
+  pins: GeocodingPinEntry[];
+  streets: GeocodingStreetEntry[];
+} {
+  const rawProcess = msg["process"];
+  if (!Array.isArray(rawProcess)) return { pins: [], streets: [] };
+
+  const steps = rawProcess.filter(
+    (s): s is Record<string, unknown> =>
+      isRecord(s) && typeof s["step"] === "string",
+  );
+
+  // Prefer last completed geocoding step
+  const geocodingSteps = steps.filter((s) => s["step"] === "geocoding");
+  if (geocodingSteps.length > 0) {
+    const last = geocodingSteps[geocodingSteps.length - 1];
+    return {
+      pins: (Array.isArray(last["pins"]) ? last["pins"] : []) as GeocodingPinEntry[],
+      streets: (Array.isArray(last["streets"]) ? last["streets"] : []) as GeocodingStreetEntry[],
+    };
+  }
+
+  // Fall back: merge geocodingBatch entries for the most recent runId (interrupted run)
+  const batchSteps = steps.filter(
+    (s): s is Record<string, unknown> & { runId: string } =>
+      s["step"] === "geocodingBatch" && typeof s["runId"] === "string",
+  );
+  if (batchSteps.length === 0) return { pins: [], streets: [] };
+
+  const lastRunId = batchSteps[batchSteps.length - 1].runId;
+  const batchesForRun = batchSteps.filter((s) => s["runId"] === lastRunId);
+  return {
+    pins: batchesForRun.flatMap(
+      (s) => (Array.isArray(s["pins"]) ? s["pins"] : []) as GeocodingPinEntry[],
+    ),
+    streets: batchesForRun.flatMap(
+      (s) => (Array.isArray(s["streets"]) ? s["streets"] : []) as GeocodingStreetEntry[],
+    ),
+  };
+}
 
 async function cachePin(
   db: Awaited<ReturnType<typeof import("@/lib/db").getDb>>,
@@ -38,29 +89,55 @@ async function cachePin(
     return;
   }
 
-  const addresses = (msg.addresses ?? []) as Address[];
-  if (addresses.length === 0) {
-    console.error(
-      `❌ Message "${messageId}" has no geocoded addresses. Has it been ingested?`,
+  const normalized = normalizePinAddress(address);
+
+  // Primary source: geocoding process step (supports both complete and interrupted runs)
+  const { pins } = extractGeocodingData(msg);
+  let match = pins.find((p) => p.key === normalized);
+
+  // Fallback: message.addresses[] (for messages ingested before the geocoding step was added)
+  if (!match) {
+    const legacyAddresses = (msg.addresses ?? []) as Address[];
+    const legacyMatch = legacyAddresses.find(
+      (a) =>
+        normalizePinAddress(a.originalText) === normalized ||
+        normalizePinAddress(a.formattedAddress) === normalized,
     );
-    process.exitCode = 1;
-    return;
+    if (legacyMatch) {
+      match = {
+        key: normalized,
+        originalText: legacyMatch.originalText,
+        formattedAddress: legacyMatch.formattedAddress,
+        coordinates: legacyMatch.coordinates,
+        geoJson: legacyMatch.geoJson,
+      };
+    }
   }
 
-  const normalized = normalizePinAddress(address);
-  const match = addresses.find(
-    (a) =>
-      normalizePinAddress(a.originalText) === normalized ||
-      normalizePinAddress(a.formattedAddress) === normalized,
-  );
-
   if (!match) {
+    const hasPins = pins.length > 0;
     console.error(
-      `❌ Address "${address}" (normalized: "${normalized}") not found in message addresses.`,
+      `❌ Address "${address}" (normalized: "${normalized}") not found in ${
+        hasPins ? "geocoding step pins" : "message addresses"
+      }.`,
     );
-    console.error(`   Available addresses:`);
-    for (const a of addresses) {
-      console.error(`   - "${a.originalText}" / "${a.formattedAddress}"`);
+    if (hasPins) {
+      console.error(`   Available pins:`);
+      for (const p of pins) {
+        console.error(`   - "${p.originalText}" / "${p.formattedAddress}"`);
+      }
+    } else {
+      const legacyAddresses = (msg.addresses ?? []) as Address[];
+      if (legacyAddresses.length > 0) {
+        console.error(`   Available addresses:`);
+        for (const a of legacyAddresses) {
+          console.error(`   - "${a.originalText}" / "${a.formattedAddress}"`);
+        }
+      } else {
+        console.error(
+          `   Message has no geocoded data. Has it been ingested?`,
+        );
+      }
     }
     process.exitCode = 1;
     return;
@@ -112,67 +189,26 @@ async function cacheStreet(
     return;
   }
 
-  const streets = (msg.streets ?? []) as StreetSection[];
-  if (streets.length === 0) {
-    console.error(
-      `❌ Message "${messageId}" has no street sections. Has it been ingested?`,
-    );
-    process.exitCode = 1;
-    return;
-  }
-
   const normalized = normalizePinAddress(streetName);
-  const matchedStreet = streets.find(
-    (s) => normalizePinAddress(s.street) === normalized,
-  );
 
-  if (!matchedStreet) {
-    console.error(
-      `❌ Street "${streetName}" (normalized: "${normalized}") not found in message streets.`,
-    );
-    console.error(`   Available streets:`);
-    for (const s of streets) {
-      console.error(`   - "${s.street}"`);
-    }
-    process.exitCode = 1;
-    return;
-  }
-
-  // Read pre-stored street geometry from message.process (written during ingestion)
-  type ProcessStep = { step: string; result: unknown };
-  type StoredStreetGeometry = {
-    key: string;
-    originalName: string;
-    geometry: Feature<MultiLineString> | string;
-  };
-  const processSteps =
-    ((msg as Record<string, unknown>).process as ProcessStep[] | undefined) ??
-    [];
-  // Use the last streetGeometries step in case the message was re-ingested
-  const streetGeometriesSteps = processSteps.filter(
-    (s) => s.step === "streetGeometries",
-  );
-  const streetGeometriesStep =
-    streetGeometriesSteps[streetGeometriesSteps.length - 1];
-  const storedGeometriesResult = streetGeometriesStep?.result;
-  if (storedGeometriesResult !== undefined && !Array.isArray(storedGeometriesResult)) {
-    console.error(
-      `❌ Invalid street geometries format in message.process for message "${messageId}".`,
-    );
-    console.error(`   Expected an array of stored street geometries.`);
-    process.exitCode = 1;
-    return;
-  }
-  const storedGeometries = (storedGeometriesResult ?? []) as StoredStreetGeometry[];
-  const storedEntry = storedGeometries.find((g) => g.key === normalized);
+  // Read street geometry from the geocoding process step
+  const { streets } = extractGeocodingData(msg);
+  const storedEntry = streets.find((g) => g.key === normalized);
 
   if (!storedEntry) {
     console.error(
-      `❌ No geometry found for "${streetName}" in message.process.`,
+      `❌ No geometry found for "${streetName}" (normalized: "${normalized}") in message.process.`,
     );
-    console.error(
-      `   Re-ingest the message first to populate street geometries.`,
-    );
+    if (streets.length > 0) {
+      console.error(`   Available streets:`);
+      for (const s of streets) {
+        console.error(`   - "${s.originalName}"`);
+      }
+    } else {
+      console.error(
+        `   Message has no geocoded street geometries. Re-ingest the message first.`,
+      );
+    }
     process.exitCode = 1;
     return;
   }
@@ -187,25 +223,27 @@ async function cacheStreet(
   }
 
   let geometry: Feature<MultiLineString>;
-  if (typeof storedEntry.geometry === "string") {
-    try {
-      geometry = JSON.parse(storedEntry.geometry) as Feature<MultiLineString>;
-    } catch {
-      console.error(
-        `❌ Invalid street geometry value in message.process for messageId "${messageId}" and key "${normalized}".`,
-      );
-      console.error(
-        `   The stored geometry value could not be parsed as JSON. Check the data and try again.`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-  } else {
-    geometry = storedEntry.geometry;
+  try {
+    geometry = JSON.parse(storedEntry.geometry) as Feature<MultiLineString>;
+  } catch {
+    console.error(
+      `❌ Invalid street geometry value in message.process for messageId "${messageId}" and key "${normalized}".`,
+    );
+    console.error(
+      `   The stored geometry value could not be parsed as JSON. Check the data and try again.`,
+    );
+    process.exitCode = 1;
+    return;
   }
+
+  const streets2 = (msg.streets ?? []) as StreetSection[];
+  const matchedStreet = streets2.find(
+    (s) => normalizePinAddress(s.street) === normalized,
+  );
+
   await db.geocodeCacheStreets.insertOne({
     key: normalized,
-    originalText: matchedStreet.street,
+    originalText: matchedStreet?.street ?? storedEntry.originalName,
     geoJson: geometry,
     sourceService: "overpass",
     sourceMessageId: messageId,

--- a/ingest/scripts/geocode-cache-add.ts
+++ b/ingest/scripts/geocode-cache-add.ts
@@ -103,31 +103,6 @@ function extractGeocodingData(msg: Record<string, unknown>): {
     };
   }
 
-  // Legacy fallback: read street geometries from the old streetGeometries process step
-  // (messages ingested before the geocoding step was introduced)
-  const legacySteps = steps.filter((s) => s["step"] === "streetGeometries");
-  if (legacySteps.length > 0) {
-    const last = legacySteps[legacySteps.length - 1];
-    const rawGeometries = Array.isArray(last["result"]) ? last["result"] : [];
-    const legacyStreets: GeocodingStreetEntry[] = rawGeometries
-      .filter(
-        (g): g is Record<string, unknown> =>
-          isRecord(g) &&
-          typeof g["key"] === "string" &&
-          typeof g["originalName"] === "string" &&
-          (typeof g["geometry"] === "string" || isRecord(g["geometry"])),
-      )
-      .map((g) => ({
-        key: g["key"] as string,
-        originalName: g["originalName"] as string,
-        geometry:
-          typeof g["geometry"] === "string"
-            ? (g["geometry"] as string)
-            : JSON.stringify(g["geometry"]),
-      }));
-    return { pins: [], streets: legacyStreets };
-  }
-
   return { pins: [], streets: [] };
 }
 

--- a/web/app/api/geocode-cache/geometries/route.ts
+++ b/web/app/api/geocode-cache/geometries/route.ts
@@ -13,22 +13,6 @@ function isRecordArray(v: unknown): v is Record<string, unknown>[] {
 function isCoordinates(v: unknown): v is { lat: number; lng: number } {
   return isRecord(v) && typeof v.lat === "number" && typeof v.lng === "number";
 }
-interface ProcessStep {
-  step: string;
-  result: unknown;
-}
-
-function isProcessStep(v: unknown): v is ProcessStep {
-  return isRecord(v) && typeof v.step === "string";
-}
-
-interface StoredStreetGeometry {
-  key: string;
-  originalName: string;
-  geometry:
-    | { type: "Feature"; geometry: { type: string; coordinates: number[][][] } }
-    | string;
-}
 
 interface GeoJsonFeature {
   type: string;
@@ -43,16 +27,83 @@ function isGeoJsonFeature(v: unknown): v is GeoJsonFeature {
   return Array.isArray(geom.coordinates);
 }
 
-function isStoredStreetGeometry(v: unknown): v is StoredStreetGeometry {
-  if (!isRecord(v)) return false;
-  if (typeof v.key !== "string") return false;
-  if (typeof v.originalName !== "string") return false;
-  // geometry stored as JSON string (new format) or object (legacy)
-  if (typeof v.geometry === "string") return true;
-  const geo = v.geometry;
-  if (!isRecord(geo)) return false;
-  const inner = geo.geometry;
-  return isRecord(inner) && inner.type === "MultiLineString";
+interface GeocodingPinEntry {
+  key: string;
+  formattedAddress?: string;
+  coordinates: unknown;
+}
+
+interface GeocodingStreetEntry {
+  key: string;
+  geometry: string;
+}
+
+function isGeocodingPinEntry(v: unknown): v is GeocodingPinEntry {
+  return isRecord(v) && typeof v["key"] === "string";
+}
+
+function isGeocodingStreetEntry(v: unknown): v is GeocodingStreetEntry {
+  return (
+    isRecord(v) &&
+    typeof v["key"] === "string" &&
+    typeof v["geometry"] === "string"
+  );
+}
+
+type GeocodingStepData = {
+  pins: GeocodingPinEntry[];
+  streets: GeocodingStreetEntry[];
+};
+
+/**
+ * Extract geocoded pins and streets from a message's process[] array.
+ * Prefers the final `geocoding` step. For interrupted runs (no `geocoding` step),
+ * falls back to merging all `geocodingBatch` entries for the most recent runId.
+ */
+function extractGeocodingData(
+  msg: Record<string, unknown>,
+): GeocodingStepData {
+  const rawProcess = msg["process"];
+  if (!Array.isArray(rawProcess)) return { pins: [], streets: [] };
+
+  const steps = rawProcess.filter(
+    (s): s is Record<string, unknown> =>
+      isRecord(s) && typeof s["step"] === "string",
+  );
+
+  // Prefer last completed geocoding step
+  const geocodingSteps = steps.filter((s) => s["step"] === "geocoding");
+  if (geocodingSteps.length > 0) {
+    const last = geocodingSteps[geocodingSteps.length - 1];
+    return {
+      pins: Array.isArray(last["pins"])
+        ? last["pins"].filter(isGeocodingPinEntry)
+        : [],
+      streets: Array.isArray(last["streets"])
+        ? last["streets"].filter(isGeocodingStreetEntry)
+        : [],
+    };
+  }
+
+  // Fall back: merge geocodingBatch entries for the most recent runId (interrupted run)
+  const batchSteps = steps.filter(
+    (s): s is Record<string, unknown> & { runId: string } =>
+      s["step"] === "geocodingBatch" && typeof s["runId"] === "string",
+  );
+  if (batchSteps.length === 0) return { pins: [], streets: [] };
+
+  const lastRunId = batchSteps[batchSteps.length - 1].runId;
+  const batchesForRun = batchSteps.filter((s) => s.runId === lastRunId);
+  return {
+    pins: batchesForRun.flatMap((s) =>
+      Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
+    ),
+    streets: batchesForRun.flatMap((s) =>
+      Array.isArray(s["streets"])
+        ? s["streets"].filter(isGeocodingStreetEntry)
+        : [],
+    ),
+  };
 }
 
 export async function GET(request: Request) {
@@ -82,6 +133,9 @@ export async function GET(request: Request) {
 
   try {
     const db = await getDb();
+    const messages = await Promise.all(
+      messageIds.map((id) => db.messages.findById(id)),
+    );
 
     if (type === "pin") {
       const items: {
@@ -91,16 +145,29 @@ export async function GET(request: Request) {
         formattedAddress: string;
       }[] = [];
 
-      const pinMessages = await Promise.all(
-        messageIds.map((id) => db.messages.findById(id)),
-      );
-      for (const [index, msg] of pinMessages.entries()) {
+      for (const [index, msg] of messages.entries()) {
         if (!msg) continue;
         const id = messageIds[index];
 
+        // Primary: geocoding step pins (supports both complete and interrupted runs)
+        const { pins } = extractGeocodingData(msg);
+        const pinEntry = pins.find((p) => p.key === key);
+        if (pinEntry && isCoordinates(pinEntry.coordinates)) {
+          items.push({
+            messageId: id,
+            lat: pinEntry.coordinates.lat,
+            lng: pinEntry.coordinates.lng,
+            formattedAddress:
+              typeof pinEntry.formattedAddress === "string"
+                ? pinEntry.formattedAddress
+                : key,
+          });
+          continue;
+        }
+
+        // Fallback: message.addresses[] (for messages ingested before the geocoding step)
         const rawAddresses = msg.addresses ?? [];
         if (!isRecordArray(rawAddresses)) continue;
-
         const match = rawAddresses.find(
           (a) =>
             normalizePinAddress(
@@ -111,9 +178,7 @@ export async function GET(request: Request) {
             ) === key,
         );
         if (!match) continue;
-
         if (!isCoordinates(match.coordinates)) continue;
-
         items.push({
           messageId: id,
           lat: match.coordinates.lat,
@@ -134,45 +199,23 @@ export async function GET(request: Request) {
       coordinates: { lat: number; lng: number }[][];
     }[] = [];
 
-    const streetMessages = await Promise.all(
-      messageIds.map((id) => db.messages.findById(id)),
-    );
-    for (const [index, msg] of streetMessages.entries()) {
+    for (const [index, msg] of messages.entries()) {
       if (!msg) continue;
       const id = messageIds[index];
 
-      const rawProcess = msg.process ?? [];
-      if (!Array.isArray(rawProcess)) continue;
-
-      // Use the last streetGeometries step in case the message was re-ingested
-      const processSteps = rawProcess.filter(isProcessStep);
-      const streetGeometrySteps = processSteps.filter(
-        (s) => s.step === "streetGeometries",
-      );
-      const step = streetGeometrySteps[streetGeometrySteps.length - 1];
-      if (!step) continue;
-
-      const rawGeometries = Array.isArray(step.result) ? step.result : [];
-      const entry = rawGeometries
-        .filter(isStoredStreetGeometry)
-        .find((g) => g.key === key);
+      const { streets } = extractGeocodingData(msg);
+      const entry = streets.find((s) => s.key === key);
       if (!entry) continue;
 
-      // geometry may be stored as a JSON string (new) or object (legacy)
-      let multiLine: { type: string; coordinates: number[][][] } | null = null;
-      if (typeof entry.geometry === "string") {
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(entry.geometry);
-        } catch (err) {
-          console.error("Invalid stored geometry JSON", { messageId: id, err });
-          continue;
-        }
-        if (!isGeoJsonFeature(parsed)) continue;
-        multiLine = parsed.geometry;
-      } else {
-        multiLine = entry.geometry.geometry;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(entry.geometry);
+      } catch (err) {
+        console.error("Invalid stored geometry JSON", { messageId: id, err });
+        continue;
       }
+      if (!isGeoJsonFeature(parsed)) continue;
+      const multiLine = parsed.geometry;
       if (multiLine.type !== "MultiLineString") continue;
 
       // Convert GeoJSON [lng, lat] → Google Maps { lat, lng }

--- a/web/app/api/geocode-cache/geometries/route.ts
+++ b/web/app/api/geocode-cache/geometries/route.ts
@@ -90,20 +90,50 @@ function extractGeocodingData(
     (s): s is Record<string, unknown> & { runId: string } =>
       s["step"] === "geocodingBatch" && typeof s["runId"] === "string",
   );
-  if (batchSteps.length === 0) return { pins: [], streets: [] };
+  if (batchSteps.length > 0) {
+    const lastRunId = batchSteps[batchSteps.length - 1].runId;
+    const batchesForRun = batchSteps.filter((s) => s.runId === lastRunId);
+    return {
+      pins: batchesForRun.flatMap((s) =>
+        Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
+      ),
+      streets: batchesForRun.flatMap((s) =>
+        Array.isArray(s["streets"])
+          ? s["streets"].filter(isGeocodingStreetEntry)
+          : [],
+      ),
+    };
+  }
 
-  const lastRunId = batchSteps[batchSteps.length - 1].runId;
-  const batchesForRun = batchSteps.filter((s) => s.runId === lastRunId);
-  return {
-    pins: batchesForRun.flatMap((s) =>
-      Array.isArray(s["pins"]) ? s["pins"].filter(isGeocodingPinEntry) : [],
-    ),
-    streets: batchesForRun.flatMap((s) =>
-      Array.isArray(s["streets"])
-        ? s["streets"].filter(isGeocodingStreetEntry)
-        : [],
-    ),
-  };
+  // Legacy fallback: read street geometries from the old streetGeometries process step
+  // (messages ingested before the geocoding step was introduced)
+  const legacySteps = steps.filter((s) => s["step"] === "streetGeometries");
+  if (legacySteps.length > 0) {
+    const last = legacySteps[legacySteps.length - 1];
+    const rawGeometries = Array.isArray(last["result"]) ? last["result"] : [];
+    const legacyStreets: GeocodingStreetEntry[] = rawGeometries
+      .filter(
+        (g): g is Record<string, unknown> =>
+          isRecord(g) &&
+          typeof g["key"] === "string" &&
+          typeof g["originalName"] === "string" &&
+          (typeof g["geometry"] === "string" || isGeoJsonFeature(g["geometry"])),
+      )
+      .map((g) => {
+        const key = g["key"];
+        const geometry = g["geometry"];
+        return {
+          key: typeof key === "string" ? key : "",
+          geometry:
+            typeof geometry === "string"
+              ? geometry
+              : JSON.stringify(geometry),
+        };
+      });
+    return { pins: [], streets: legacyStreets };
+  }
+
+  return { pins: [], streets: [] };
 }
 
 export async function GET(request: Request) {

--- a/web/app/api/geocode-cache/geometries/route.ts
+++ b/web/app/api/geocode-cache/geometries/route.ts
@@ -105,34 +105,6 @@ function extractGeocodingData(
     };
   }
 
-  // Legacy fallback: read street geometries from the old streetGeometries process step
-  // (messages ingested before the geocoding step was introduced)
-  const legacySteps = steps.filter((s) => s["step"] === "streetGeometries");
-  if (legacySteps.length > 0) {
-    const last = legacySteps[legacySteps.length - 1];
-    const rawGeometries = Array.isArray(last["result"]) ? last["result"] : [];
-    const legacyStreets: GeocodingStreetEntry[] = rawGeometries
-      .filter(
-        (g): g is Record<string, unknown> =>
-          isRecord(g) &&
-          typeof g["key"] === "string" &&
-          typeof g["originalName"] === "string" &&
-          (typeof g["geometry"] === "string" || isGeoJsonFeature(g["geometry"])),
-      )
-      .map((g) => {
-        const key = g["key"];
-        const geometry = g["geometry"];
-        return {
-          key: typeof key === "string" ? key : "",
-          geometry:
-            typeof geometry === "string"
-              ? geometry
-              : JSON.stringify(geometry),
-        };
-      });
-    return { pins: [], streets: legacyStreets };
-  }
-
   return { pins: [], streets: [] };
 }
 


### PR DESCRIPTION
Closes #341

## Problem

Geocoding calls external APIs (Google, Overpass, Cadastre) and can take several minutes for messages with many locations. If the ingestion script was interrupted mid-run (crash, SIGKILL, timeout), all geocoding work done up to that point was lost.

## Solution

Results are now persisted to the database incrementally as they arrive, using two new process step names:

- **`geocodingBatch`** — appended every ≥10 resolved items (delta only: pins/streets resolved since the last flush). Written during the run.
- **`geocoding`** — written once when geocoding completes via a read-modify-write: strips all `geocodingBatch` entries for the run and replaces them with a single final step containing all pins and streets.

A `runId` (UUID) ties all batch entries to their run. If the script is interrupted, the batch entries survive and are visible in the admin page geometry panel immediately, so they can be promoted to the persistent cache without waiting for a full re-ingest.

## Changes

- **New**: `ingest/messageIngest/geocoding-progress-tracker.ts` — `GeocodingProgressTracker` with `recordPins`, `recordStreet`, `recordAttempted`, and `finalize`
- **Modified**: `ingest/messageIngest/geocode-addresses.ts` — tracker threaded through `geocodePins` and `geocodeAddressesFromExtractedData`
- **Modified**: `ingest/messageIngest/index.ts` — tracker created and wired in `performGeocodingWithErrorHandling`; `finalize()` called in `finally` block; `streetGeometries` process step removed (replaced by `geocoding` step)
- **Modified**: `ingest/scripts/geocode-cache-add.ts` — reads from `geocoding`/`geocodingBatch` step; fallback to `message.addresses[]` for pins on old messages
- **Modified**: `web/app/api/geocode-cache/geometries/route.ts` — same `extractGeocodingData` logic; `streetGeometries` step logic removed
- **Modified**: `docs/features/geocode-cache.md` — updated to reflect new geocoding progress behaviour and recovery workflow
