### PR TITLE
refactor(ingest): improve readability in geocode-addresses and index

### DIFF
--- a/ingest/messageIngest/from-sources.test.ts
+++ b/ingest/messageIngest/from-sources.test.ts
@@ -230,7 +230,7 @@ describe("filterByAge", () => {
   const createSource = (daysAgo: number): SourceDocument => {
     const date = new Date();
     date.setUTCHours(0, 0, 0, 0); // Set to midnight UTC to avoid timezone issues
-    date.setDate(date.getDate() - daysAgo);
+    date.setUTCDate(date.getUTCDate() - daysAgo);
 
     return {
       url: `https://example.com/post-${daysAgo}`,

--- a/ingest/messageIngest/geocode-addresses.test.ts
+++ b/ingest/messageIngest/geocode-addresses.test.ts
@@ -5,8 +5,15 @@ import {
   geocodeAddressesFromExtractedData,
   getValidPreResolvedCoordinates,
 } from "./geocode-addresses";
+import type { GeocodingProgressTracker } from "./geocoding-progress-tracker";
 import type { StreetSection, Address, ExtractedLocations } from "@/lib/types";
 import { BOUNDS } from "@oboapp/shared";
+import { geocodeIntersectionsForStreets } from "@/geocoding/router";
+import {
+  getStreetGeometryCached,
+  getStreetGeometryFromOverpass,
+  hasStreetGeometryQueried,
+} from "@/geocoding/overpass/service";
 
 // Set LOCALITY for tests
 beforeEach(() => {
@@ -32,6 +39,13 @@ vi.mock("@/geocoding/router", () => ({
 
 vi.mock("@/geocoding/overpass/service", () => ({
   overpassGeocodeAddresses: vi.fn().mockResolvedValue([]),
+  getStreetGeometryCached: vi.fn().mockReturnValue(null),
+  getStreetGeometryFromOverpass: vi.fn().mockResolvedValue(null),
+  hasStreetGeometryQueried: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/delay", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/geocoding/cache", () => ({
@@ -423,5 +437,104 @@ describe("getValidPreResolvedCoordinates", () => {
     expect(result).not.toBeNull();
     expect(result!.lat).toBe(42.693576);
     expect(result!.lng).toBe(23.35161);
+  });
+});
+
+describe("geocodeStreetIntersections tracker recording", () => {
+  function createMockTracker(): GeocodingProgressTracker {
+    return {
+      recordPins: vi.fn().mockResolvedValue(undefined),
+      recordStreet: vi.fn().mockResolvedValue(undefined),
+      recordAttempted: vi.fn(),
+      flushPending: vi.fn().mockResolvedValue(undefined),
+      finalize: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(geocodeIntersectionsForStreets).mockResolvedValue(new Map());
+    vi.mocked(getStreetGeometryCached).mockReturnValue(null);
+    vi.mocked(hasStreetGeometryQueried).mockReturnValue(false);
+    vi.mocked(getStreetGeometryFromOverpass).mockResolvedValue(null);
+  });
+
+  it("records geometry exactly once for a street with valid geotagged coordinates", async () => {
+    const mockGeometry = {
+      type: "Feature" as const,
+      geometry: { type: "MultiLineString" as const, coordinates: [] },
+      properties: null,
+    };
+    vi.mocked(getStreetGeometryFromOverpass).mockResolvedValue(mockGeometry);
+
+    const tracker = createMockTracker();
+    const extractedData: ExtractedLocations = {
+      withSpecificAddress: true,
+      cityWide: false,
+      busStops: [],
+      pins: [],
+      streets: [
+        {
+          street: "ул. Оборище",
+          from: "бул. Дондуков",
+          fromCoordinates: { lat: 42.693576, lng: 23.35161 }, // valid Sofia coords
+          to: "ул. Г. С. Раковски",
+          toCoordinates: { lat: 42.693259, lng: 23.354973 }, // valid Sofia coords
+          timespans: [{ start: "01.02.2026 00:00", end: "02.02.2026 00:00" }],
+        },
+      ],
+      cadastralProperties: [],
+    };
+
+    await geocodeAddressesFromExtractedData(extractedData, undefined, tracker);
+
+    // Both endpoints pre-resolved → street enters only the geotagged pass,
+    // not streetsNeedingGeocoding → geometry recorded exactly once
+    expect(tracker.recordStreet).toHaveBeenCalledTimes(1);
+    expect(tracker.recordAttempted).not.toHaveBeenCalled();
+    // Overpass geometry fetch called exactly once (from geotagged pass)
+    expect(getStreetGeometryFromOverpass).toHaveBeenCalledTimes(1);
+    expect(getStreetGeometryFromOverpass).toHaveBeenCalledWith("ул. Оборище");
+  });
+
+  it("does not double-record a street whose geotagged coordinates fail bounds validation", async () => {
+    // Overpass intersection geocoding succeeds (endpoints resolved via Overpass)
+    vi.mocked(geocodeIntersectionsForStreets).mockResolvedValue(
+      new Map([
+        ["Corner A", { lat: 42.69, lng: 23.32 }],
+        ["Corner B", { lat: 42.695, lng: 23.325 }],
+      ]),
+    );
+    // No street geometry found for this street
+    vi.mocked(getStreetGeometryFromOverpass).mockResolvedValue(null);
+
+    const tracker = createMockTracker();
+    const extractedData: ExtractedLocations = {
+      withSpecificAddress: true,
+      cityWide: false,
+      busStops: [],
+      pins: [],
+      streets: [
+        {
+          street: "ул. Оборище",
+          from: "Corner A",
+          fromCoordinates: { lat: 43.0, lng: 23.3 }, // outside Sofia bounds → rejected by validation
+          to: "Corner B",
+          toCoordinates: { lat: 43.1, lng: 23.3 }, // outside Sofia bounds → rejected by validation
+          timespans: [{ start: "01.02.2026 00:00", end: "02.02.2026 00:00" }],
+        },
+      ],
+      cadastralProperties: [],
+    };
+
+    await geocodeAddressesFromExtractedData(extractedData, undefined, tracker);
+
+    // Invalid coords → endpoints not in preGeocodedMap after geotagged pass →
+    // fullyPreResolvedStreets is empty → geotagged tracker pass is skipped.
+    // Street enters streetsNeedingGeocoding and is recorded exactly once there.
+    expect(tracker.recordAttempted).toHaveBeenCalledTimes(1);
+    expect(tracker.recordAttempted).toHaveBeenCalledWith(1);
+    expect(tracker.recordStreet).not.toHaveBeenCalled();
+    // Geometry fetch attempted exactly once, not twice
+    expect(getStreetGeometryFromOverpass).toHaveBeenCalledTimes(1);
   });
 });

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -12,6 +12,7 @@ import {
   StreetSection,
   Coordinates,
 } from "@/lib/types";
+import type { Feature, MultiLineString } from "geojson";
 import type { CadastralGeometry } from "@/geocoding/cadastre/service";
 import type { IngestErrorRecorder } from "@/lib/ingest-errors";
 import { logger } from "@/lib/logger";
@@ -304,6 +305,60 @@ function processStreetEndpointsWithPreResolvedCoordinates(
 }
 
 /**
+ * Fetch and record street geometry in the progress tracker.
+ * If `beforeFetch` is provided it is called immediately before any new Overpass
+ * network request (used by callers to apply per-request rate-limiting delays).
+ * Tracker errors are caught and logged without affecting geocoding results.
+ */
+async function recordStreetGeometryInTracker(
+  street: StreetSection,
+  tracker: GeocodingProgressTracker,
+  fetchers: {
+    getStreetGeometryCached: (name: string) => Feature<MultiLineString> | null;
+    getStreetGeometryFromOverpass: (name: string) => Promise<Feature<MultiLineString> | null>;
+    hasStreetGeometryQueried: (name: string) => boolean;
+  },
+  beforeFetch?: () => Promise<void>,
+): Promise<void> {
+  try {
+    let geometry = fetchers.getStreetGeometryCached(street.street);
+    const wasCached = !!geometry;
+    if (!geometry && !fetchers.hasStreetGeometryQueried(street.street)) {
+      if (beforeFetch) await beforeFetch();
+      geometry = await fetchers.getStreetGeometryFromOverpass(street.street);
+    }
+    if (geometry) {
+      logger.debug("Recording street geometry in progress tracker", {
+        street: street.street,
+        source: wasCached ? "cache" : "overpass",
+      });
+      await tracker.recordStreet({
+        key: normalizePinAddress(street.street),
+        originalName: street.street,
+        // Stringify to avoid Firestore nested-array rejection (coordinates: number[][][])
+        geometry: JSON.stringify(geometry),
+      });
+    } else {
+      logger.debug("No street geometry found; incrementing attempted count", {
+        street: street.street,
+      });
+      tracker.recordAttempted(1);
+    }
+  } catch (trackerError) {
+    logger.warn(
+      "Failed to record street in progress tracker — geocoding result unaffected",
+      {
+        street: street.street,
+        error:
+          trackerError instanceof Error
+            ? trackerError.message
+            : String(trackerError),
+      },
+    );
+  }
+}
+
+/**
  * Helper: Geocode street intersections using Overpass
  */
 async function geocodeStreetIntersections(
@@ -321,6 +376,9 @@ async function geocodeStreetIntersections(
     addresses,
   );
 
+  // Hoist Overpass service imports once — used for both geocoding and tracker recording below
+  const overpassFetchers = await import("@/geocoding/overpass/service");
+
   // Filter to streets that still need Overpass geocoding
   const streetsNeedingGeocoding = extractedData.streets.filter(
     (street) =>
@@ -328,9 +386,6 @@ async function geocodeStreetIntersections(
   );
 
   if (streetsNeedingGeocoding.length > 0) {
-    const { getStreetGeometryCached, getStreetGeometryFromOverpass, hasStreetGeometryQueried } =
-      await import("@/geocoding/overpass/service");
-
     logger.debug("Geocoding streets via Overpass (per-street)", {
       total: streetsNeedingGeocoding.length,
       trackerActive: !!tracker,
@@ -357,92 +412,44 @@ async function geocodeStreetIntersections(
       });
 
       if (tracker) {
-        try {
-          // getStreetGeometryCached is populated as a side-effect of
-          // geocodeSingleIntersection (which calls getStreetGeometryFromOverpass
-          // on both street names to find their geometric crossing). If the street
-          // geometry still isn't cached, the street's endpoints were resolved via
-          // geotagged coordinates (Overpass intersection queries were skipped).
-          // In that case fetch the geometry explicitly — same as the original
-          // post-geocoding loop in index.ts used to do.
-          let geometry = getStreetGeometryCached(street.street);
-          const wasCached = !!geometry;
-          if (!geometry && !hasStreetGeometryQueried(street.street)) {
-            logger.debug("Fetching street geometry explicitly (geotagged endpoints)", { street: street.street });
-            geometry = await getStreetGeometryFromOverpass(street.street);
-          }
-          if (geometry) {
-            logger.debug("Recording street geometry in progress tracker", {
-              street: street.street,
-              source: wasCached ? "cache" : "overpass",
-            });
-            await tracker.recordStreet({
-              key: normalizePinAddress(street.street),
-              originalName: street.street,
-              // Stringify to avoid Firestore nested-array rejection (coordinates: number[][][])
-              geometry: JSON.stringify(geometry),
-            });
-          } else {
-            logger.debug("No street geometry found; incrementing attempted count", { street: street.street });
-            tracker.recordAttempted(1);
-          }
-        } catch (trackerError) {
-          logger.warn("Failed to record street in progress tracker — geocoding result unaffected", {
-            street: street.street,
-            error: trackerError instanceof Error ? trackerError.message : String(trackerError),
-          });
-        }
+        // getStreetGeometryCached is populated as a side-effect of
+        // geocodeSingleIntersection (which calls getStreetGeometryFromOverpass
+        // on both street names to find their geometric crossing). If the street
+        // geometry still isn't cached, the street's endpoints were resolved via
+        // geotagged coordinates (Overpass intersection queries were skipped).
+        // In that case fetch the geometry explicitly.
+        await recordStreetGeometryInTracker(street, tracker, overpassFetchers);
       }
     }
   }
 
   // Streets whose both endpoints were pre-resolved from geotagged coordinates
   // never enter streetsNeedingGeocoding, so their geometry wasn't fetched above.
-  // Record them now using an explicit Overpass lookup (same rate-limit guard as
-  // the per-street loop to avoid hitting an already-queried street twice).
-  if (tracker && extractedData.streets.length > 0) {
+  // Record them now using an explicit Overpass lookup with per-request rate limiting.
+  if (tracker) {
     const geotaggedStreets = extractedData.streets.filter(
       (street) =>
         preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
     );
+
     if (geotaggedStreets.length > 0) {
       logger.debug("Recording geotagged streets in progress tracker", {
         count: geotaggedStreets.length,
       });
-      const { getStreetGeometryCached, getStreetGeometryFromOverpass, hasStreetGeometryQueried } =
-        await import("@/geocoding/overpass/service");
+
       const { delay } = await import("@/lib/delay");
       let fetchCount = 0;
+
       for (const street of geotaggedStreets) {
-        try {
-          let geometry = getStreetGeometryCached(street.street);
-          const wasCached = !!geometry;
-          if (!geometry && !hasStreetGeometryQueried(street.street)) {
-            logger.debug("Fetching geometry for geotagged street", { street: street.street });
+        await recordStreetGeometryInTracker(
+          street,
+          tracker,
+          overpassFetchers,
+          async () => {
             if (fetchCount > 0) await delay(500);
-            geometry = await getStreetGeometryFromOverpass(street.street);
             fetchCount++;
-          }
-          if (geometry) {
-            logger.debug("Recording geotagged street geometry in progress tracker", {
-              street: street.street,
-              source: wasCached ? "cache" : "overpass",
-            });
-            await tracker.recordStreet({
-              key: normalizePinAddress(street.street),
-              originalName: street.street,
-              geometry: JSON.stringify(geometry),
-            });
-          } else {
-            logger.debug("No geometry for geotagged street; incrementing attempted count", { street: street.street });
-            tracker.recordAttempted(1);
-          }
-        } catch (trackerError) {
-          logger.warn("Failed to record geotagged street in progress tracker — geocoding result unaffected", {
-            street: street.street,
-            error: trackerError instanceof Error ? trackerError.message : String(trackerError),
-          });
-        }
+          },
+        );
       }
     }
   }

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -478,6 +478,7 @@ async function geocodeStreetIntersections(
  */
 async function geocodeCadastralProperties(
   extractedData: ExtractedLocations,
+  tracker?: GeocodingProgressTracker,
 ): Promise<Map<string, CadastralGeometry> | undefined> {
   if (
     !extractedData.cadastralProperties ||
@@ -497,6 +498,7 @@ async function geocodeCadastralProperties(
     total: identifiers.length,
   });
 
+  tracker?.recordAttempted(identifiers.length);
   return cadastralGeometries;
 }
 
@@ -507,6 +509,7 @@ async function geocodeBusStopsFromExtractedData(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
   addresses: Address[],
+  tracker?: GeocodingProgressTracker,
 ): Promise<void> {
   if (!extractedData.busStops || extractedData.busStops.length === 0) {
     return;
@@ -523,6 +526,8 @@ async function geocodeBusStopsFromExtractedData(
     geocoded: geocodedBusStops.length,
     total: extractedData.busStops.length,
   });
+
+  tracker?.recordAttempted(extractedData.busStops.length);
 }
 
 /**
@@ -533,6 +538,7 @@ async function geocodeEducationalFacilitiesFromExtractedData(
   preGeocodedMap: Map<string, Coordinates>,
   addresses: Address[],
   ingestErrors?: IngestErrorRecorder,
+  tracker?: GeocodingProgressTracker,
 ): Promise<void> {
   if (
     !extractedData.educationalFacilities ||
@@ -550,6 +556,8 @@ async function geocodeEducationalFacilitiesFromExtractedData(
   geocoded.forEach((addr) => {
     preGeocodedMap.set(addr.originalText, addr.coordinates);
   });
+
+  tracker?.recordAttempted(extractedData.educationalFacilities.length);
 }
 
 /**
@@ -576,21 +584,9 @@ export async function geocodeAddressesFromExtractedData(
   // Geocode each location type using specialized services
   await geocodePins(extractedData, preGeocodedMap, addresses, tracker);
   await geocodeStreetIntersections(extractedData, preGeocodedMap, addresses, tracker);
-  const cadastralGeometries = await geocodeCadastralProperties(extractedData);
-  tracker?.recordAttempted(extractedData.cadastralProperties?.length ?? 0);
-  await geocodeBusStopsFromExtractedData(
-    extractedData,
-    preGeocodedMap,
-    addresses,
-  );
-  tracker?.recordAttempted(extractedData.busStops?.length ?? 0);
-  await geocodeEducationalFacilitiesFromExtractedData(
-    extractedData,
-    preGeocodedMap,
-    addresses,
-    ingestErrors,
-  );
-  tracker?.recordAttempted(extractedData.educationalFacilities?.length ?? 0);
+  const cadastralGeometries = await geocodeCadastralProperties(extractedData, tracker);
+  await geocodeBusStopsFromExtractedData(extractedData, preGeocodedMap, addresses, tracker);
+  await geocodeEducationalFacilitiesFromExtractedData(extractedData, preGeocodedMap, addresses, ingestErrors, tracker);
 
   // Deduplicate addresses before returning
   const deduplicatedAddresses = deduplicateAddresses(addresses);

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -377,6 +377,14 @@ async function geocodeStreetIntersections(
     addresses,
   );
 
+  // Snapshot streets whose BOTH endpoints were successfully pre-resolved from source
+  // geotags. Must be captured here, before Overpass geocoding adds more entries to
+  // preGeocodedMap. Streets with invalid geotagged coordinates (rejected by bounds
+  // validation) will not have their endpoints in the map and will not appear here.
+  const fullyPreResolvedStreets = extractedData.streets.filter(
+    (street) => preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
+  );
+
   // Import Overpass service only when a tracker is active — these fetchers are only used
   // for tracker recording; the static overpassGeocodeAddresses handles the geocoding itself
   const overpassFetchers = tracker
@@ -430,32 +438,24 @@ async function geocodeStreetIntersections(
   // Streets whose both endpoints were pre-resolved from geotagged coordinates
   // never enter streetsNeedingGeocoding, so their geometry wasn't fetched above.
   // Record them now using an explicit Overpass lookup with per-request rate limiting.
-  // Use fromCoordinates/toCoordinates (source-provided geotags) to identify this
-  // set, since preGeocodedMap is also populated with Overpass results at this point.
-  if (tracker) {
-    const geotaggedStreets = extractedData.streets.filter(
-      (street) => !!street.fromCoordinates && !!street.toCoordinates,
-    );
+  if (tracker && fullyPreResolvedStreets.length > 0) {
+    logger.debug("Recording geotagged streets in progress tracker", {
+      count: fullyPreResolvedStreets.length,
+    });
 
-    if (geotaggedStreets.length > 0) {
-      logger.debug("Recording geotagged streets in progress tracker", {
-        count: geotaggedStreets.length,
-      });
+    const { delay } = await import("@/lib/delay");
+    let fetchCount = 0;
 
-      const { delay } = await import("@/lib/delay");
-      let fetchCount = 0;
-
-      for (const street of geotaggedStreets) {
-        await recordStreetGeometryInTracker(
-          street,
-          tracker,
-          overpassFetchers!,
-          async () => {
-            if (fetchCount > 0) await delay(500);
-            fetchCount++;
-          },
-        );
-      }
+    for (const street of fullyPreResolvedStreets) {
+      await recordStreetGeometryInTracker(
+        street,
+        tracker,
+        overpassFetchers!,
+        async () => {
+          if (fetchCount > 0) await delay(500);
+          fetchCount++;
+        },
+      );
     }
   }
 

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -430,10 +430,11 @@ async function geocodeStreetIntersections(
   // Streets whose both endpoints were pre-resolved from geotagged coordinates
   // never enter streetsNeedingGeocoding, so their geometry wasn't fetched above.
   // Record them now using an explicit Overpass lookup with per-request rate limiting.
+  // Use fromCoordinates/toCoordinates (source-provided geotags) to identify this
+  // set, since preGeocodedMap is also populated with Overpass results at this point.
   if (tracker) {
     const geotaggedStreets = extractedData.streets.filter(
-      (street) =>
-        preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
+      (street) => !!street.fromCoordinates && !!street.toCoordinates,
     );
 
     if (geotaggedStreets.length > 0) {

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -308,7 +308,8 @@ function processStreetEndpointsWithPreResolvedCoordinates(
  * Fetch and record street geometry in the progress tracker.
  * If `beforeFetch` is provided it is called immediately before any new Overpass
  * network request (used by callers to apply per-request rate-limiting delays).
- * Tracker errors are caught and logged without affecting geocoding results.
+ * Errors during Overpass fetching or progress-tracker recording are caught and
+ * logged without affecting geocoding results.
  */
 async function recordStreetGeometryInTracker(
   street: StreetSection,
@@ -346,7 +347,7 @@ async function recordStreetGeometryInTracker(
     }
   } catch (trackerError) {
     logger.warn(
-      "Failed to record street in progress tracker — geocoding result unaffected",
+      "Failed to fetch or record street geometry — geocoding result unaffected",
       {
         street: street.street,
         error:
@@ -376,8 +377,11 @@ async function geocodeStreetIntersections(
     addresses,
   );
 
-  // Hoist Overpass service imports once — used for both geocoding and tracker recording below
-  const overpassFetchers = await import("@/geocoding/overpass/service");
+  // Import Overpass service only when a tracker is active — these fetchers are only used
+  // for tracker recording; the static overpassGeocodeAddresses handles the geocoding itself
+  const overpassFetchers = tracker
+    ? await import("@/geocoding/overpass/service")
+    : undefined;
 
   // Filter to streets that still need Overpass geocoding
   const streetsNeedingGeocoding = extractedData.streets.filter(
@@ -418,7 +422,7 @@ async function geocodeStreetIntersections(
         // geometry still isn't cached, the street's endpoints were resolved via
         // geotagged coordinates (Overpass intersection queries were skipped).
         // In that case fetch the geometry explicitly.
-        await recordStreetGeometryInTracker(street, tracker, overpassFetchers);
+        await recordStreetGeometryInTracker(street, tracker, overpassFetchers!);
       }
     }
   }
@@ -444,7 +448,7 @@ async function geocodeStreetIntersections(
         await recordStreetGeometryInTracker(
           street,
           tracker,
-          overpassFetchers,
+          overpassFetchers!,
           async () => {
             if (fetchCount > 0) await delay(500);
             fetchCount++;

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -430,10 +430,11 @@ async function geocodeStreetIntersections(
   // Streets whose both endpoints were pre-resolved from geotagged coordinates
   // never enter streetsNeedingGeocoding, so their geometry wasn't fetched above.
   // Record them now using an explicit Overpass lookup with per-request rate limiting.
+  // Use the complement of streetsNeedingGeocoding (computed before any Overpass
+  // queries ran) to avoid double-recording streets that were just geocoded above.
   if (tracker) {
     const geotaggedStreets = extractedData.streets.filter(
-      (street) =>
-        preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
+      (street) => !streetsNeedingGeocoding.includes(street),
     );
 
     if (geotaggedStreets.length > 0) {

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -730,13 +730,13 @@ async function performGeocodingWithErrorHandling(
   addresses: Address[];
   geoJson: GeoJSONFeatureCollection | null;
 } | null> {
-  const toDo =
+  const totalLocations =
     (extractedLocations.pins?.length ?? 0) +
     (extractedLocations.streets?.length ?? 0) +
     (extractedLocations.cadastralProperties?.length ?? 0) +
     (extractedLocations.busStops?.length ?? 0) +
     (extractedLocations.educationalFacilities?.length ?? 0);
-  const tracker = createGeocodingProgressTracker(messageId, toDo);
+  const tracker = createGeocodingProgressTracker(messageId, totalLocations);
   let geocodingSucceeded = false;
 
   try {
@@ -976,35 +976,23 @@ async function handlePrecomputedGeoJsonData(
   const { validateAndFallback } = await import("@/lib/timespan-utils");
   const validated = validateAndFallback(timespanStart, timespanEnd, crawledAt);
 
-  if (!markdownText) {
-    if (addresses.length > 0) {
-      await updateMessage(messageId, {
-        addresses,
-        pins,
-        streets: [],
-        cadastralProperties: [],
-        timespanStart: validated.timespanStart,
-        timespanEnd: validated.timespanEnd,
-      });
-    } else {
-      await updateMessage(messageId, {
-        timespanStart: validated.timespanStart,
-        timespanEnd: validated.timespanEnd,
-      });
-    }
-    return addresses;
-  }
+  const locationFields = { addresses, pins, streets: [], cadastralProperties: [] };
 
-  await updateMessage(messageId, {
-    markdownText,
-    responsibleEntity: "",
-    addresses,
-    pins,
-    streets: [],
-    cadastralProperties: [],
-    timespanStart: validated.timespanStart,
-    timespanEnd: validated.timespanEnd,
-  });
+  if (markdownText) {
+    await updateMessage(messageId, {
+      markdownText,
+      responsibleEntity: "",
+      ...locationFields,
+      timespanStart: validated.timespanStart,
+      timespanEnd: validated.timespanEnd,
+    });
+  } else {
+    await updateMessage(messageId, {
+      ...(addresses.length > 0 ? locationFields : {}),
+      timespanStart: validated.timespanStart,
+      timespanEnd: validated.timespanEnd,
+    });
+  }
 
   return addresses;
 }


### PR DESCRIPTION
- [x] Fix: snapshot `fullyPreResolvedStreets` from `preGeocodedMap` immediately after `processStreetEndpointsWithPreResolvedCoordinates` (before Overpass geocoding runs), replacing the `fromCoordinates/toCoordinates` check that was broken for streets with invalid geotagged coords
- [x] Add unit tests: tracker-enabled paths including the invalid-coords case that could previously cause double-recording