### PR TITLE
Add open data section and clean up /open-source page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/web/app/open-source/AISection.tsx
+++ b/web/app/open-source/AISection.tsx
@@ -48,12 +48,13 @@ export default function AISection() {
         ))}
       </ul>
       <p className="mt-4 text-sm text-neutral">
-        * Възможно е да са участвали и други, но тези виждаме в{" "}
+        * Възможно е да са участвали и други, но тези са видими в{" "}
         <a
           href="https://github.com/vbuch/oboapp/graphs/contributors"
           target="_blank"
           rel="noopener noreferrer"
           className="text-link hover:text-link-hover hover:underline"
+          lang="en"
         >
           Contributors
         </a>

--- a/web/app/open-source/DepsSection.tsx
+++ b/web/app/open-source/DepsSection.tsx
@@ -45,9 +45,6 @@ export default function DepsSection() {
       <h2 id="deps-heading" className="text-2xl font-bold text-foreground mb-2">
         Направено върху отворен код
       </h2>
-      <p className="text-sm text-neutral mb-6">
-        Специално внимание заслужават проектите, поддържани от един човек.
-      </p>
       <ul className="space-y-4">
         {DEPS.map((dep) => (
           <li

--- a/web/app/open-source/GitHubRepoLink.tsx
+++ b/web/app/open-source/GitHubRepoLink.tsx
@@ -22,7 +22,7 @@ export default function GitHubRepoLink() {
       }}
     >
       <GitHubIcon className="size-4 shrink-0" />
-      vbuch/oboapp в GitHub
+      oboapp в GitHub
     </a>
   );
 }

--- a/web/app/open-source/LicenceSection.tsx
+++ b/web/app/open-source/LicenceSection.tsx
@@ -1,4 +1,3 @@
-import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
 import GitHubRepoLink from "./GitHubRepoLink";
 
 export default function LicenceSection() {
@@ -30,26 +29,6 @@ export default function LicenceSection() {
         <li lang="en">fork it</li>
         <li lang="en">host it</li>
       </ul>
-      <div className="flex flex-wrap gap-4 items-center mb-6">
-        <a
-          href="https://www.facebook.com/valery.buchinsky/posts/pfbid0DNVQJ9RgUKmjabwKAccm7MqVNX2Lu3icgCiXu8Vg9dszpdf4LDMsesqYnfoe16kSl"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-link hover:text-link-hover hover:underline text-sm"
-        >
-          Публикация във Facebook
-          <ExternalLinkIcon className="size-3" />
-        </a>
-        <a
-          href="https://www.linkedin.com/feed/update/urn:li:activity:7422898120201568256/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-link hover:text-link-hover hover:underline text-sm"
-        >
-          Публикация в LinkedIn
-          <ExternalLinkIcon className="size-3" />
-        </a>
-      </div>
       <GitHubRepoLink />
     </section>
   );

--- a/web/app/open-source/OpenDataSection.tsx
+++ b/web/app/open-source/OpenDataSection.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+
+const OPEN_DATA_SOURCES = [
+  {
+    name: "Sofia Traffic GTFS",
+    url: "https://gtfs.sofiatraffic.bg",
+    description: "спирки и маршрути на градския транспорт",
+  },
+  {
+    name: "Sofia Plan",
+    url: "https://sofiaplan.bg",
+    description: "училища и детски градини от Столична община",
+  },
+  {
+    name: "OpenStreetMap",
+    url: "https://www.openstreetmap.org",
+    description: "геокодиране и улична геометрия",
+  },
+  {
+    name: "sensor.community",
+    url: "https://sensor.community",
+    description: "данни за качеството на въздуха от граждански сензори",
+  },
+] as const;
+
+export default function OpenDataSection() {
+  return (
+    <section
+      aria-labelledby="open-data-heading"
+      className="bg-white rounded-lg shadow-md p-6 md:p-8 border border-neutral-border"
+    >
+      <h2
+        id="open-data-heading"
+        className="text-2xl font-bold text-foreground mb-2"
+      >
+        Направено върху отворени данни
+      </h2>
+      <p className="text-sm text-neutral mb-6">
+        Приложението се крепи на публично достъпни данни, предоставени безплатно
+        от общността.
+      </p>
+      <ul className="space-y-4">
+        {OPEN_DATA_SOURCES.map((source) => (
+          <li
+            key={source.name}
+            className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5"
+          >
+            <a
+              href={source.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-link hover:text-link-hover hover:underline"
+            >
+              {source.name}
+            </a>
+            <span className="text-sm text-neutral">{source.description}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-6 text-sm text-neutral">
+        <Link
+          href="/sources"
+          className="text-link hover:text-link-hover hover:underline"
+        >
+          Всички източници на данни →
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/web/app/open-source/page.tsx
+++ b/web/app/open-source/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import LicenceSection from "./LicenceSection";
 import ContributorsSection from "./ContributorsSection";
 import DepsSection from "./DepsSection";
+import OpenDataSection from "./OpenDataSection";
 import AISection from "./AISection";
 import SponsorsSection from "./SponsorsSection";
 
@@ -63,11 +64,14 @@ export default async function OpenSourcePage() {
             <LicenceSection />
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
               <ContributorsSection contributors={contributors} />
-              <AISection />
               <SponsorsSection />
+              <AISection />
             </div>
           </div>
-          <DepsSection />
+          <div className="space-y-8">
+            <DepsSection />
+            <OpenDataSection />
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
- Add CLAUDE.md importing AGENTS.md for Claude Code tooling
- New OpenDataSection: credits Sofia Traffic GTFS, Sofia Plan (schools/kindergartens), OpenStreetMap, and sensor.community
- Remove Facebook/LinkedIn social links from LicenceSection
- Minor copy tweaks (AISection text, GitHubRepoLink label)
- Drop subtitle from DepsSection