### PR TITLE
Improve OG metadata for social sharing and replace hardcoded app name

### DIFF
--- a/web/app/history/page.tsx
+++ b/web/app/history/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import HistoryContent from "./HistoryContent";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export const metadata: Metadata = {
-  title: "Исторически данни | OboApp",
+  title: `Исторически данни | ${APP_NAME}`,
   description:
     "Топлинна карта на исторически данни от всички събрани съобщения",
 };

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -35,16 +35,14 @@ export const metadata: Metadata = {
   openGraph: {
     title: APP_NAME,
     description,
-    images: [PWA_ICON_PATHS.icon512],
     locale: "bg_BG",
     type: "website",
     siteName: APP_NAME,
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: APP_NAME,
     description,
-    images: [PWA_ICON_PATHS.icon512],
   },
 };
 

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import NotFoundLayout from "@/components/NotFoundLayout";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export const metadata: Metadata = {
-  title: "Страницата не е намерена - OboApp",
+  title: `Страницата не е намерена - ${APP_NAME}`,
   description: "Страницата, която търсите, не съществува.",
 };
 

--- a/web/app/open-source/LicenceSection.tsx
+++ b/web/app/open-source/LicenceSection.tsx
@@ -1,4 +1,5 @@
 import GitHubRepoLink from "./GitHubRepoLink";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export default function LicenceSection() {
   return (
@@ -13,7 +14,7 @@ export default function LicenceSection() {
         Лиценз: Unlicense
       </h2>
       <p className="text-neutral mb-4">
-        OboApp е публикуван под{" "}
+        {APP_NAME} е публикуван под{" "}
         <a
           href="https://github.com/vbuch/oboapp/blob/main/LICENSE"
           target="_blank"

--- a/web/app/open-source/SponsorsSection.tsx
+++ b/web/app/open-source/SponsorsSection.tsx
@@ -1,4 +1,5 @@
 import SentryIcon from "@/components/icons/SentryIcon";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export default function SponsorsSection() {
   return (
@@ -30,7 +31,7 @@ export default function SponsorsSection() {
         </li>
       </ul>
       <p className="mt-4 text-sm text-neutral">
-        Sentry спонсорира OboApp с безплатен акаунт за проследяване на грешки
+        Sentry спонсорира {APP_NAME} с безплатен акаунт за проследяване на грешки
         като отворен код.
       </p>
     </section>

--- a/web/app/open-source/page.tsx
+++ b/web/app/open-source/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
+import { APP_NAME } from "@/lib/pwa-metadata";
 import LicenceSection from "./LicenceSection";
 import ContributorsSection from "./ContributorsSection";
 import DepsSection from "./DepsSection";
@@ -9,10 +10,26 @@ import SponsorsSection from "./SponsorsSection";
 
 export const revalidate = 86400;
 
+const PAGE_TITLE = `${APP_NAME} е отворен | ${APP_NAME}`;
+const PAGE_DESCRIPTION =
+  `${APP_NAME} е отворен код. Вижте лиценза, библиотеките, на които се крепи, и хората, които го изграждат.`;
+
 export const metadata: Metadata = {
-  title: "OboApp е отворен | OboApp",
-  description:
-    "OboApp е отворен код. Вижте лиценза, библиотеките, на които се крепи, и хората, които го изграждат.",
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/open-source",
+    siteName: APP_NAME,
+    locale: "bg_BG",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
 };
 
 interface GitHubContributor {
@@ -56,7 +73,7 @@ export default async function OpenSourcePage() {
         </div>
 
         <h1 className="text-3xl font-bold text-foreground mb-8">
-          OboApp е отворен
+          {APP_NAME} е отворен
         </h1>
 
         <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 items-start">

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { APP_NAME } from "@/lib/pwa-metadata";
 import { getConfiguredLocalityDescription } from "@/lib/locality-metadata";
 import { buildOgCard } from "@/lib/og-card";
 
+export const runtime = "nodejs";
 export const alt = APP_NAME;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -11,6 +11,8 @@ const LOCALITY_NAMES: Record<string, string> = {
 };
 
 export default function OgImage() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ?? "https://oboapp.online";
   const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
   const cityName = LOCALITY_NAMES[locality] ?? "София";
   const tagline = `Следи събитията в ${cityName}`;
@@ -41,10 +43,31 @@ export default function OgImage() {
             display: "flex",
           }}
         />
+
+        {/* Logo in white rounded container, matching Header style */}
+        <div
+          style={{
+            display: "flex",
+            backgroundColor: "#ffffff",
+            borderRadius: "20px",
+            padding: "16px",
+            marginBottom: "36px",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${baseUrl}/logo.png`}
+            width={120}
+            height={120}
+            alt=""
+          />
+        </div>
+
         {/* App name */}
         <div
           style={{
-            fontSize: 120,
+            fontSize: 96,
             fontWeight: 700,
             color: "#ffffff",
             letterSpacing: "-2px",
@@ -53,12 +76,13 @@ export default function OgImage() {
         >
           {APP_NAME}
         </div>
+
         {/* Tagline */}
         <div
           style={{
-            fontSize: 40,
-            color: "rgba(255,255,255,0.7)",
-            marginTop: 24,
+            fontSize: 36,
+            color: "#5DADE2",
+            marginTop: 16,
             display: "flex",
           }}
         >

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,71 @@
+import { ImageResponse } from "next/og";
+import { APP_NAME } from "@/lib/pwa-metadata";
+
+export const runtime = "edge";
+export const alt = APP_NAME;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const LOCALITY_NAMES: Record<string, string> = {
+  "bg.sofia": "София",
+};
+
+export default function OgImage() {
+  const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
+  const cityName = LOCALITY_NAMES[locality] ?? "София";
+  const tagline = `Следи събитията в ${cityName}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#2c3e50",
+          position: "relative",
+        }}
+      >
+        {/* Brand red accent bar at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "10px",
+            backgroundColor: "#E74C3C",
+            display: "flex",
+          }}
+        />
+        {/* App name */}
+        <div
+          style={{
+            fontSize: 120,
+            fontWeight: 700,
+            color: "#ffffff",
+            letterSpacing: "-2px",
+            display: "flex",
+          }}
+        >
+          {APP_NAME}
+        </div>
+        {/* Tagline */}
+        <div
+          style={{
+            fontSize: 40,
+            color: "rgba(255,255,255,0.7)",
+            marginTop: 24,
+            display: "flex",
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,95 +1,15 @@
 import { ImageResponse } from "next/og";
 import { APP_NAME } from "@/lib/pwa-metadata";
+import { getConfiguredLocalityDescription } from "@/lib/locality-metadata";
+import { buildOgCard } from "@/lib/og-card";
 
-export const runtime = "edge";
 export const alt = APP_NAME;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-const LOCALITY_NAMES: Record<string, string> = {
-  "bg.sofia": "София",
-};
-
 export default function OgImage() {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL ?? "https://oboapp.online";
-  const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
-  const cityName = LOCALITY_NAMES[locality] ?? "София";
-  const tagline = `Следи събитията в ${cityName}`;
-
   return new ImageResponse(
-    (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#2c3e50",
-          position: "relative",
-        }}
-      >
-        {/* Brand red accent bar at top */}
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            height: "10px",
-            backgroundColor: "#E74C3C",
-            display: "flex",
-          }}
-        />
-
-        {/* Logo in white rounded container, matching Header style */}
-        <div
-          style={{
-            display: "flex",
-            backgroundColor: "#ffffff",
-            borderRadius: "20px",
-            padding: "16px",
-            marginBottom: "36px",
-            boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
-          }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={`${baseUrl}/logo.png`}
-            width={120}
-            height={120}
-            alt=""
-          />
-        </div>
-
-        {/* App name */}
-        <div
-          style={{
-            fontSize: 96,
-            fontWeight: 700,
-            color: "#ffffff",
-            letterSpacing: "-2px",
-            display: "flex",
-          }}
-        >
-          {APP_NAME}
-        </div>
-
-        {/* Tagline */}
-        <div
-          style={{
-            fontSize: 36,
-            color: "#5DADE2",
-            marginTop: 16,
-            display: "flex",
-          }}
-        >
-          {tagline}
-        </div>
-      </div>
-    ),
+    buildOgCard(getConfiguredLocalityDescription()),
     { width: 1200, height: 630 },
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,15 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import HomeContent from "@/components/HomeContent";
 import SplashScreen from "@/components/SplashScreen";
+import { getConfiguredLocalityDescription } from "@/lib/locality-metadata";
+
+export const metadata: Metadata = {
+  openGraph: {
+    url: "/",
+    description: getConfiguredLocalityDescription(),
+  },
+};
 
 export default function Home() {
   return (

--- a/web/app/settings/ApiAccessSection.tsx
+++ b/web/app/settings/ApiAccessSection.tsx
@@ -77,8 +77,8 @@ export default function ApiAccessSection({
         Публичен API достъп
       </h2>
       <p className="text-neutral text-sm mb-4">
-        API ключът ви позволява достъп до публичните данни на <span translate="no">{APP_NAME}</span> от ваши
-        приложения. Вижте{" "}
+        API ключът позволява достъп от приложения до публичните данни на{" "}
+        <span translate="no">{APP_NAME}</span>. Тук е{" "}
         <a
           href="https://api.oboapp.online/v1/docs"
           target="_blank"

--- a/web/app/settings/ApiAccessSection.tsx
+++ b/web/app/settings/ApiAccessSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { buttonStyles, buttonSizes } from "@/lib/theme";
+import { APP_NAME } from "@/lib/pwa-metadata";
 import { borderRadius } from "@/lib/colors";
 import type { ApiClient } from "@/lib/types";
 
@@ -76,7 +77,7 @@ export default function ApiAccessSection({
         Публичен API достъп
       </h2>
       <p className="text-neutral text-sm mb-4">
-        API ключът ви позволява достъп до публичните данни на <span translate="no">OboApp</span> от ваши
+        API ключът ви позволява достъп до публичните данни на <span translate="no">{APP_NAME}</span> от ваши
         приложения. Вижте{" "}
         <a
           href="https://api.oboapp.online/v1/docs"

--- a/web/app/settings/SubscribeDevicePrompt.tsx
+++ b/web/app/settings/SubscribeDevicePrompt.tsx
@@ -6,6 +6,7 @@ import {
   getNotificationInstructions,
   PlatformInfo,
 } from "@/lib/platform-detection";
+import { APP_NAME } from "@/lib/pwa-metadata";
 import { buttonStyles, buttonSizes } from "@/lib/theme";
 import { borderRadius } from "@/lib/colors";
 
@@ -41,8 +42,8 @@ export default function SubscribeDevicePrompt({
         {hasAnySubscriptions
           ? "Текущото устройство не е абонирано за известия."
           : isGuestUser
-            ? <>Няма абонамент за известия на това устройство. Това е основната задача на <span translate="no">OboApp</span>. Абонирай се!</>
-            : <>Няма абонамент за известия на нито едно устройство. Това е основната задача на <span translate="no">OboApp</span>. Абонирай се!</>}
+            ? <>Няма абонамент за известия на това устройство. Това е основната задача на <span translate="no">{APP_NAME}</span>. Абонирай се!</>
+            : <>Няма абонамент за известия на нито едно устройство. Това е основната задача на <span translate="no">{APP_NAME}</span>. Абонирай се!</>}
       </p>
 
       {platformInfo.requiresPWAInstall && (

--- a/web/app/sources/[sourceId]/layout.tsx
+++ b/web/app/sources/[sourceId]/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import sourcesData from "@/lib/sources";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 interface Props {
   children: React.ReactNode;
@@ -15,21 +16,20 @@ export async function generateMetadata({
 
   if (!source) {
     return {
-      title: "Източник не е намерен - OboApp",
+      title: `Източник не е намерен - ${APP_NAME}`,
     };
   }
 
-  const baseUrl = "https://oboapp.online";
-  const logoUrl = `${baseUrl}/sources/${source.id}.png`;
+  const logoUrl = `/sources/${source.id}.png`;
 
   return {
-    title: `${source.name} - OboApp`,
+    title: `${source.name} - ${APP_NAME}`,
     description: `Последни съобщения от ${source.name}`,
     openGraph: {
-      title: `${source.name} - OboApp`,
+      title: `${source.name} - ${APP_NAME}`,
       description: `Последни съобщения от ${source.name}`,
-      url: `${baseUrl}/sources/${source.id}`,
-      siteName: "OboApp",
+      url: `/sources/${source.id}`,
+      siteName: APP_NAME,
       images: [
         {
           url: logoUrl,
@@ -43,9 +43,9 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary",
-      title: `${source.name} - OboApp`,
+      title: `${source.name} - ${APP_NAME}`,
       description: `Последни съобщения от ${source.name}`,
-      images: [logoUrl],
+      images: [{ url: logoUrl }],
     },
   };
 }

--- a/web/app/sources/page.tsx
+++ b/web/app/sources/page.tsx
@@ -4,9 +4,10 @@ import { getCurrentLocalitySources } from "@/lib/source-utils";
 import geocodingSources from "@/lib/geocoding.json";
 import SourceCard from "@/components/SourceCard";
 import GeocodingSourceCard from "@/components/GeocodingSourceCard";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export const metadata: Metadata = {
-  title: "Източници - OboApp",
+  title: `Източници - ${APP_NAME}`,
   description: "Източници на данни за събития и уведомления",
 };
 

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -3,6 +3,7 @@ import { APP_NAME } from "@/lib/pwa-metadata";
 import { getConfiguredLocalityDescription } from "@/lib/locality-metadata";
 import { buildOgCard } from "@/lib/og-card";
 
+export const runtime = "nodejs";
 export const alt = APP_NAME;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -1,0 +1,71 @@
+import { ImageResponse } from "next/og";
+import { APP_NAME } from "@/lib/pwa-metadata";
+
+export const runtime = "edge";
+export const alt = APP_NAME;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const LOCALITY_NAMES: Record<string, string> = {
+  "bg.sofia": "София",
+};
+
+export default function TwitterImage() {
+  const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
+  const cityName = LOCALITY_NAMES[locality] ?? "София";
+  const tagline = `Следи събитията в ${cityName}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#2c3e50",
+          position: "relative",
+        }}
+      >
+        {/* Brand red accent bar at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "10px",
+            backgroundColor: "#E74C3C",
+            display: "flex",
+          }}
+        />
+        {/* App name */}
+        <div
+          style={{
+            fontSize: 120,
+            fontWeight: 700,
+            color: "#ffffff",
+            letterSpacing: "-2px",
+            display: "flex",
+          }}
+        >
+          {APP_NAME}
+        </div>
+        {/* Tagline */}
+        <div
+          style={{
+            fontSize: 40,
+            color: "rgba(255,255,255,0.7)",
+            marginTop: 24,
+            display: "flex",
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -11,6 +11,8 @@ const LOCALITY_NAMES: Record<string, string> = {
 };
 
 export default function TwitterImage() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ?? "https://oboapp.online";
   const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
   const cityName = LOCALITY_NAMES[locality] ?? "София";
   const tagline = `Следи събитията в ${cityName}`;
@@ -41,10 +43,31 @@ export default function TwitterImage() {
             display: "flex",
           }}
         />
+
+        {/* Logo in white rounded container, matching Header style */}
+        <div
+          style={{
+            display: "flex",
+            backgroundColor: "#ffffff",
+            borderRadius: "20px",
+            padding: "16px",
+            marginBottom: "36px",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${baseUrl}/logo.png`}
+            width={120}
+            height={120}
+            alt=""
+          />
+        </div>
+
         {/* App name */}
         <div
           style={{
-            fontSize: 120,
+            fontSize: 96,
             fontWeight: 700,
             color: "#ffffff",
             letterSpacing: "-2px",
@@ -53,12 +76,13 @@ export default function TwitterImage() {
         >
           {APP_NAME}
         </div>
+
         {/* Tagline */}
         <div
           style={{
-            fontSize: 40,
-            color: "rgba(255,255,255,0.7)",
-            marginTop: 24,
+            fontSize: 36,
+            color: "#5DADE2",
+            marginTop: 16,
             display: "flex",
           }}
         >

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -1,95 +1,15 @@
 import { ImageResponse } from "next/og";
 import { APP_NAME } from "@/lib/pwa-metadata";
+import { getConfiguredLocalityDescription } from "@/lib/locality-metadata";
+import { buildOgCard } from "@/lib/og-card";
 
-export const runtime = "edge";
 export const alt = APP_NAME;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-const LOCALITY_NAMES: Record<string, string> = {
-  "bg.sofia": "София",
-};
-
 export default function TwitterImage() {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL ?? "https://oboapp.online";
-  const locality = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
-  const cityName = LOCALITY_NAMES[locality] ?? "София";
-  const tagline = `Следи събитията в ${cityName}`;
-
   return new ImageResponse(
-    (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#2c3e50",
-          position: "relative",
-        }}
-      >
-        {/* Brand red accent bar at top */}
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            height: "10px",
-            backgroundColor: "#E74C3C",
-            display: "flex",
-          }}
-        />
-
-        {/* Logo in white rounded container, matching Header style */}
-        <div
-          style={{
-            display: "flex",
-            backgroundColor: "#ffffff",
-            borderRadius: "20px",
-            padding: "16px",
-            marginBottom: "36px",
-            boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
-          }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={`${baseUrl}/logo.png`}
-            width={120}
-            height={120}
-            alt=""
-          />
-        </div>
-
-        {/* App name */}
-        <div
-          style={{
-            fontSize: 96,
-            fontWeight: 700,
-            color: "#ffffff",
-            letterSpacing: "-2px",
-            display: "flex",
-          }}
-        >
-          {APP_NAME}
-        </div>
-
-        {/* Tagline */}
-        <div
-          style={{
-            fontSize: 36,
-            color: "#5DADE2",
-            marginTop: 16,
-            display: "flex",
-          }}
-        >
-          {tagline}
-        </div>
-      </div>
-    ),
+    buildOgCard(getConfiguredLocalityDescription()),
     { width: 1200, height: 630 },
   );
 }

--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 interface FooterProps {
   readonly className?: string;
@@ -8,7 +9,7 @@ interface FooterProps {
 
 const NAV_LINKS = [
   { href: "/kak-se-rodi", label: "Как се роди?" },
-  { href: "/open-source", label: "OboApp е отворен" },
+  { href: "/open-source", label: `${APP_NAME} е отворен` },
   { href: "/sources", label: "Източници на данни" },
   { href: "/ingest-errors", label: "Съобщения с грешки" },
   { href: "/history", label: "Исторически данни" },
@@ -23,7 +24,7 @@ export default function Footer({ className = "" }: FooterProps) {
         {/* Navigation links — 1 col mobile, 2 col sm, 3 col lg */}
         <div>
           <h3 className="font-bold text-lg mb-4 text-foreground">
-            За <span translate="no">OboApp</span>
+            За <span translate="no">{APP_NAME}</span>
           </h3>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-2 text-sm">
             {NAV_LINKS.map(({ href, label }) => (

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useAuth } from "@/lib/auth-context";
 import { zIndex } from "@/lib/colors";
+import { APP_NAME } from "@/lib/pwa-metadata";
 import UserMenu from "@/components/UserMenu";
 import NotificationBell from "@/components/NotificationBell";
 import UserSilhouetteIcon from "@/components/icons/UserSilhouetteIcon";
@@ -46,7 +47,7 @@ export default function Header() {
                   >
                     <Image
                       src="/logo.png"
-                      alt="OboApp"
+                      alt={APP_NAME}
                       width={96}
                       height={96}
                       className="h-9 sm:h-16 md:h-20 w-auto object-contain"
@@ -58,7 +59,7 @@ export default function Header() {
               </Link>
               <div>
                 <h1 className="text-sm sm:text-base md:text-lg font-bold" translate="no">
-                  OboApp
+                  {APP_NAME}
                 </h1>
               </div>
             </div>

--- a/web/components/SplashScreen.tsx
+++ b/web/components/SplashScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { APP_NAME } from "@/lib/pwa-metadata";
 
 export default function SplashScreen() {
   const [logoError, setLogoError] = useState(false);
@@ -13,7 +14,7 @@ export default function SplashScreen() {
           <div className="animate-pulse">
             <Image
               src="/logo.png"
-              alt="OboApp"
+              alt={APP_NAME}
               width={120}
               height={120}
               onError={() => setLogoError(true)}

--- a/web/components/onboarding/SubscribePrompt.tsx
+++ b/web/components/onboarding/SubscribePrompt.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { buttonStyles, buttonSizes } from "@/lib/theme";
+import { APP_NAME } from "@/lib/pwa-metadata";
 import { borderRadius, zIndex } from "@/lib/colors";
 
 interface SubscribePromptProps {
@@ -30,7 +31,7 @@ export default function SubscribePrompt({ onClose }: SubscribePromptProps) {
               </h3>
               <p className="text-warning text-sm mb-3">
                 Имаш зони на интерес, но не си абониран/а за известия. Това е
-                основната задача на OboApp!
+                основната задача на {APP_NAME}!
               </p>
               <div className="flex gap-2">
                 <Link

--- a/web/lib/og-card.tsx
+++ b/web/lib/og-card.tsx
@@ -1,0 +1,81 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { APP_NAME } from "@/lib/pwa-metadata";
+
+// Read once at module load — avoids an HTTP round-trip and works in Node.js runtime
+const logoBuffer = readFileSync(join(process.cwd(), "public/logo.png"));
+const LOGO_SRC = `data:image/png;base64,${logoBuffer.toString("base64")}`;
+
+/**
+ * Shared JSX card for opengraph-image and twitter-image.
+ * Rendered by next/og ImageResponse (Satori) — not a browser component.
+ */
+export function buildOgCard(tagline: string) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#2c3e50",
+        position: "relative",
+      }}
+    >
+      {/* Brand red accent bar at top */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "10px",
+          backgroundColor: "#E74C3C",
+          display: "flex",
+        }}
+      />
+
+      {/* Logo in white rounded container, matching Header style */}
+      <div
+        style={{
+          display: "flex",
+          backgroundColor: "#ffffff",
+          borderRadius: "20px",
+          padding: "16px",
+          marginBottom: "36px",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- Satori (next/og) does not support next/image */}
+        <img src={LOGO_SRC} width={120} height={120} alt="" />
+      </div>
+
+      {/* App name */}
+      <div
+        style={{
+          fontSize: 96,
+          fontWeight: 700,
+          color: "#ffffff",
+          letterSpacing: "-2px",
+          display: "flex",
+        }}
+      >
+        {APP_NAME}
+      </div>
+
+      {/* Tagline */}
+      <div
+        style={{
+          fontSize: 36,
+          color: "#5DADE2",
+          marginTop: 16,
+          display: "flex",
+        }}
+      >
+        {tagline}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `opengraph-image.tsx` and `twitter-image.tsx` using Next.js `ImageResponse` to generate a proper 1200×630 social preview card (dark blue brand background, red accent bar, app name + locality tagline) — fixes broken/missing image in Discord/Telegram/Slack previews
- Switch `twitter:card` from `summary` (small square) to `summary_large_image` (full banner)
- Remove manual `openGraph.images` from root layout — the file-based images handle this automatically with correct dimensions
- Use relative URL paths for `og:url` so `metadataBase` resolves them per environment (local vs production)
- Add `og:url` to homepage and open-source page
- Replace all hardcoded `"OboApp"` strings in UI and metadata with the `APP_NAME` constant from `lib/pwa-metadata.ts` — app name is now defined in one place

## Test plan

- [ ] Visit `/opengraph-image` and `/twitter-image` after deploy to confirm the branded card renders
- [ ] Paste the URL into a Discord DM or use [opengraph.xyz](https://www.opengraph.xyz) to verify the social preview shows the correct image, title, and description
- [ ] Check `<head>` in browser devtools for `og:image`, `og:image:width`, `og:image:height`, `twitter:card`, `twitter:image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)