### PR TITLE
ci: pass LOCALITIES variable to terraform plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ env:
   FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
   ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
   LOCALITY: ${{ vars.LOCALITY }}
+  LOCALITIES: ${{ vars.LOCALITIES || '["bg.sofia"]' }}
   GCS_GENERIC_BUCKET: ${{ vars.GCS_GENERIC_BUCKET || '' }}
   REGION: europe-west1
   IMAGE_NAME: oborishte-ingest
@@ -124,6 +125,7 @@ jobs:
             -var="firebase_project_id=$FIREBASE_PROJECT_ID" \
             -var="alert_email=$ALERT_EMAIL" \
             -var="locality=$LOCALITY" \
+            -var="localities=$LOCALITIES" \
             -var="ci_service_account_email=${{ secrets.GCP_SERVICE_ACCOUNT }}" \
             -var="gcs_generic_bucket=$GCS_GENERIC_BUCKET" \
             -out=tfplan


### PR DESCRIPTION
## Summary

Wires up the `localities` Terraform variable added in oboapp/oboapp#424 so this instance's deployment can control which city crawlers are active via a GitHub Actions variable.

## Changes

- `deploy.yml` — add `LOCALITIES: ${{ vars.LOCALITIES || '[\"bg.sofia\"]' }}` to the workflow env block and pass `-var="localities=$LOCALITIES"` to `terraform plan`

## Configuration

Set the `LOCALITIES` GitHub Actions variable in this repository's settings to a JSON list of locality IDs, e.g.:

```
["bg.sofia"]
```

Defaults to `["bg.sofia"]` if the variable is not set, preserving the current behaviour.

## Dependency

Requires oboapp/oboapp#424 to be merged and pulled into this fork before deploying.