### PR TITLE
feat: notifications tracking and reporting

### DIFF
--- a/db/src/indexes.ts
+++ b/db/src/indexes.ts
@@ -112,6 +112,16 @@ export const INDEX_DEFINITIONS: IndexDefinition[] = [
     spec: { "messageSnapshot.source": 1 },
     options: { name: "notificationMatches_messageSnapshot_source" },
   },
+  {
+    collection: "notificationMatches",
+    spec: { userId: 1, clickedAt: 1 },
+    options: { name: "userId_clickedAt", sparse: true },
+  },
+  {
+    collection: "notificationMatches",
+    spec: { userId: 1, openedAt: 1 },
+    options: { name: "userId_openedAt", sparse: true },
+  },
 
   // --- notificationSubscriptions ---
   {

--- a/ingest/firestore.indexes.json
+++ b/ingest/firestore.indexes.json
@@ -113,6 +113,42 @@
       ]
     },
     {
+      "collectionGroup": "notificationMatches",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "clickedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "notificationMatches",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "openedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "events",
       "queryScope": "COLLECTION",
       "fields": [

--- a/ingest/lib/types.ts
+++ b/ingest/lib/types.ts
@@ -102,6 +102,8 @@ export interface NotificationMatch {
   distance?: number; // Distance in meters from interest center to closest point
   deviceNotifications?: DeviceNotification[]; // Array of device-specific sends
   messageSnapshot?: MessageSnapshot; // Denormalized message data
+  clickedAt?: Date | string; // First push-notification click event timestamp
+  openedAt?: Date | string; // First explicit open/read action by the user
 }
 
 // Source Configuration

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,129 @@
+## Plan: Notifications Report Page
+
+Build a public, report-style page (linked from footer) that shows all-time notification delivery analytics, plus click/open conversion and source breakdown, by extending existing notification tracking and reusing the existing report-page + map/heatmap architecture. The heatmap will use message-derived coordinates (the exact message that triggered each notification), producing a 1:1 notification-to-message-coordinate mapping via the aggregate API.
+
+**Steps**
+
+### Phase 1 — Data model, tracking contract, and indexes
+
+- Define new notification match fields and semantics before implementation to avoid ambiguity:
+  - `openedAt`: first explicit open/read action by the user (separate from `readAt` semantics used for unread UX).
+  - `clickedAt`: first push-notification click event timestamp.
+- No new location field is required on `notificationMatches`; location will be derived from the triggering message geometry at query time (or from a report snapshot generated from that join).
+- `messageSnapshot.source` remains the source key for per-source metrics.
+- Idempotency rule: first-write-wins for `clickedAt`/`openedAt` (do not overwrite existing value).
+- Add/update shared and app-level types/schema so API and UI remain type-safe.
+- Apply "clean as you code" while touching files: fix adjacent, safely-fixable issues discovered in edited files (without expanding scope into unrelated refactors).
+- **Add DB indexes before Phase 2 writes begin** (indexes must be in place before data flows):
+  - Mongo (`db/src/indexes.ts`): compound indexes on `notificationMatches` covering `(userId, clickedAt)` and `(userId, openedAt)` for analytics aggregation and idempotent update queries.
+  - Firestore (`ingest/firestore.indexes.json`): composite indexes matching the new analytics query patterns.
+
+### Phase 2 — Capture tracking events end-to-end
+
+**`matchId` propagation (already established — extend, don't replace):**
+`notification-sender.ts` already includes `matchId` in the FCM `data` payload, and the SW template already captures it in `notificationOptions.data.matchId`, making it available in the `notificationclick` handler via `event.notification.data.matchId`. The only gap is that the current `NOTIFICATION_CLICKED` postMessage only forwards `messageId` — fix this to also forward `matchId`.
+
+**Click endpoint auth strategy:**
+Service workers cannot call authenticated endpoints directly (no Firebase auth token available in SW context). Use a two-step approach:
+
+1. SW `notificationclick` handler sends `NOTIFICATION_CLICKED` postMessage to the app client, forwarding both `messageId` and `matchId`.
+2. The app client receives the message and calls `/api/notifications/click` with the user's Firebase auth token (same `verifyAuthToken` pattern as `mark-read`).
+3. As a best-effort fallback when no app window is open, the SW can fire-and-forget a POST with `matchId` only (no user auth). The endpoint handles both cases: authenticated path verifies the notification belongs to the user before writing; unauthenticated path records the click for aggregate counts without userId attribution. Apply a 3-second `AbortController` timeout to the SW fallback fetch to avoid blocking notification navigation inside `event.waitUntil`.
+
+**Steps:**
+
+- Fix SW template to include `matchId` in the `NOTIFICATION_CLICKED` postMessage.
+- Add app-side handler for `NOTIFICATION_CLICKED` that calls `/api/notifications/click` with the auth token.
+- Add `/api/notifications/click` route: accepts `{ matchId }`, uses `verifyAuthToken` for the authenticated path (verifies notification belongs to user before writing), accepts unauthenticated requests as a fallback. First-write-wins for `clickedAt`.
+- Update the single-notification open/read route (`mark-read`) to also set `openedAt` (first-write-wins), while keeping existing `readAt` behavior for unread badge UX.
+- Keep bulk `mark-all-read` from writing `openedAt` to avoid inflating true opens.
+
+### Phase 3 — Analytics aggregation API
+
+- Add a new public report API route (`/api/notifications/report`) returning all-time aggregate payload:
+  - Top-level KPIs: notifications sent, unique users sent to, notifications clicked, notifications opened.
+  - Heatmap points from the triggering message coordinates (1:1 with notification records), with server-side filter mode: `all`/`clicked`/`opened`.
+  - Enforce privacy threshold at API level: if the selected heatmap dataset has fewer than 50 records, return no map points and a `heatmapHiddenForPrivacy: true` flag.
+  - Source breakdown from `messageSnapshot.source`: sent count, clicked count (and optional CTR field for UI).
+- **Auth/gating:** Route is unauthenticated (public aggregate data only). Gate with `hasReportPagesEnabled()` at the route level — return 503 when not configured, matching the pattern used by existing report endpoints.
+- Extract aggregation/math/filter logic into pure functions (separate module from route handler) so behavior is unit-testable without web runtime dependencies.
+- Reuse report-route behavior from existing report endpoints (node runtime, caching headers where safe, graceful 503/404 handling when report infrastructure is unavailable).
+
+### Phase 4 — New footer-linked report page
+
+- Add a new page under web report pages and gate visibility using existing report-page gating pattern (`hasReportPagesEnabled`). Depends on Phase 3 API.
+- Use page naming convention: `Notifications` in English surfaces and `Известия` in Bulgarian UI text.
+- Add footer link in "Данни и отчети" section when report pages are enabled, labeled `Известия`.
+- Build page sections:
+  - KPI cards for sent/users/clicked/opened.
+  - Heatmap component showing notification-location density from API data.
+  - Privacy-safe rendering: when API returns `heatmapHiddenForPrivacy` (dataset < 50 records), hide the map and show a clear informational message instead.
+  - Filter control to switch map dataset (`all`/`clicked`/`opened`), with clicked-through mode explicitly named.
+  - Source table/chart listing sent and clicked counts per source.
+- Keep Bulgarian UI copy in informal (ти)/neutral register according to web language rules.
+
+### Phase 5 — Tests and rollout checks
+
+- Add/adjust tests with pure-function-first coverage:
+  - Unit tests for pure aggregation/filter/coordinate extraction functions (happy paths + edge cases).
+  - Route tests for notification tracking endpoints (click/open idempotency, auth path and unauthenticated fallback behavior).
+  - API contract tests for analytics response shape, counts, and filter modes.
+  - Service worker click wiring test: assert `NOTIFICATION_CLICKED` postMessage includes `matchId`.
+  - Page-level tests for report availability gating and footer-link visibility with and without report bucket config.
+
+**Relevant files**
+
+- `/Users/Valeri_Buchinski/code/oboapp/ingest/lib/types.ts` — add new NotificationMatch fields (`clickedAt`, `openedAt`) only.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/api/messages/by-id/route.ts` — reuse message lookup patterns when joining notification matches to triggering messages for coordinates in report aggregation.
+- `/Users/Valeri_Buchinski/code/oboapp/web/lib/types.ts` — keep web type parity for new notification analytics fields.
+- `/Users/Valeri_Buchinski/code/oboapp/shared/src/schema/notification-history.schema.ts` — extend schema if history payload needs new open/click fields.
+- `/Users/Valeri_Buchinski/code/oboapp/db/src/indexes.ts` — add indexes for click/open/filter aggregation paths.
+- `/Users/Valeri_Buchinski/code/oboapp/ingest/firestore.indexes.json` — add Firestore composite indexes matching new analytics queries.
+- `/Users/Valeri_Buchinski/code/oboapp/ingest/notifications/notification-sender.ts` — ensure payload carries match identifier in URL/data for click tracking.
+- `/Users/Valeri_Buchinski/code/oboapp/web/scripts/firebase-messaging-sw.template.js` — send click tracking event on notification click.
+- `/Users/Valeri_Buchinski/code/oboapp/web/public/firebase-messaging-sw.js` — generated output updated via existing generation script.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/api/notifications/mark-read/route.ts` — write `openedAt` on explicit open.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/api/notifications/mark-all-read/route.ts` — keep unread logic without mass `openedAt` writes.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/api/notifications/click/route.ts` — new endpoint to record `clickedAt` idempotently.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/api/notifications/report/route.ts` — new aggregate analytics API for KPIs, heatmap points, and per-source metrics.
+- `/Users/Valeri_Buchinski/code/oboapp/web/components/Footer.tsx` — add new report page link under data/reports.
+- `/Users/Valeri_Buchinski/code/oboapp/web/lib/report-pages.ts` — reuse existing report gating strategy.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/notifications-report/page.tsx` — new report page shell + gating with title `Известия` (Bulgarian UI) and internal/report naming `Notifications`.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/notifications-report/NotificationsReportClient.tsx` — client UI for metrics, filters, and source breakdown.
+- `/Users/Valeri_Buchinski/code/oboapp/web/app/notifications-report/NotificationsReportMapClient.tsx` — map/heatmap renderer with clicked/opened filter.
+
+**Verification**
+
+- Run unit tests for extracted pure functions (aggregation/filter/coordinate extraction) and route tests for click/open tracking.
+- Run report API and page tests to confirm filter behavior, payload contract, and report-page gating.
+- Add explicit privacy-threshold tests: for each heatmap mode (`all`, `clicked`, `opened`), verify `< 50` records returns no points and `heatmapHiddenForPrivacy=true`, while `>= 50` returns points.
+- **SW generation pipeline:** After modifying the template, run `node web/scripts/generate-firebase-messaging-sw.mjs` (or the equivalent build step) and confirm the generated `web/public/firebase-messaging-sw.js` reflects the `matchId` change. The generated file must be committed alongside the template change.
+- Manual smoke test in browser:
+  - Send a test notification.
+  - Click notification from system tray; confirm click count increments.
+  - Open from in-app notifications list; confirm opened count increments.
+  - Confirm heatmap toggles between `all`/`clicked`/`opened`.
+  - Confirm privacy threshold behavior: with fewer than 50 records in selected mode, map is hidden and explanatory message is shown.
+  - Confirm source breakdown sent/clicked counts align with sampled records.
+- Mandatory pre-PR quality gates from AGENTS.md:
+  - In `shared/`: `pnpm build`.
+  - In `ingest/`: `pnpm lint` and `pnpm tsc --noEmit`.
+  - In `web/`: `pnpm lint` and `pnpm tsc --noEmit`.
+  - From repo root: `pnpm test:run`.
+
+**Decisions**
+
+- Page visibility: Public report page (same model as current report pages).
+- Time scope: All-time totals (no date range in this iteration).
+- Click/open model: Separate metrics for clicked and opened.
+- Reach metric: Unique users sent to (not device count as primary KPI).
+- Source breakdown: Sent + clicked counts per source.
+- Privacy guardrail: heatmap is never shown for datasets with fewer than 50 records (threshold evaluated per selected heatmap mode).
+- Included scope: Footer link (label `Известия`), tracking instrumentation, aggregate API, report page (`Notifications`/`Известия` naming), filterable heatmap by engagement mode with k-anonymity thresholding.
+- Excluded scope: Time-range filtering UI/API, advanced attribution windows, admin-only access control, retroactive coordinate backfill beyond what can be derived from existing triggering messages.
+
+**Further Considerations**
+
+1. Backfill strategy recommendation: start with forward-only tracking and show analytics from rollout timestamp; optional one-off backfill can be added later if you need historical continuity.
+2. Reliability recommendation: implement both service-worker click logging and app-side fallback logging to reduce undercount from browser/service-worker edge cases.
+3. Privacy recommendation: keep page at aggregate level only (no user-level drilldown), consistent with public report visibility choice.

--- a/web/app/api/notifications/click/__tests__/route.test.ts
+++ b/web/app/api/notifications/click/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+
+const { findByIdMock, updateOneMock } = vi.hoisted(() => ({
+  findByIdMock: vi.fn(),
+  updateOneMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn().mockResolvedValue({
+    notificationMatches: {
+      findById: findByIdMock,
+      updateOne: updateOneMock,
+    },
+  }),
+}));
+
+const { verifyAuthTokenMock } = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/verifyAuthToken", () => ({
+  verifyAuthToken: verifyAuthTokenMock,
+}));
+
+function makeRequest(body: unknown, withAuth = true) {
+  return new Request("http://localhost/api/notifications/click", {
+    method: "POST",
+    headers: {
+      ...(withAuth ? { authorization: "Bearer test-token" } : {}),
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/notifications/click", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifyAuthTokenMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("records click for authenticated user (first-write-wins)", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "match-1",
+      userId: "user-1",
+      clickedAt: null,
+    });
+    updateOneMock.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest({ matchId: "match-1" }) as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(updateOneMock).toHaveBeenCalledWith("match-1", {
+      clickedAt: expect.any(String),
+    });
+  });
+
+  it("does not overwrite existing clickedAt (first-write-wins)", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "match-1",
+      userId: "user-1",
+      clickedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({ matchId: "match-1" }) as any);
+
+    expect(response.status).toBe(200);
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when notification belongs to another user", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "match-1",
+      userId: "user-2",
+    });
+
+    const response = await POST(makeRequest({ matchId: "match-1" }) as any);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when notification not found", async () => {
+    findByIdMock.mockResolvedValue(null);
+
+    const response = await POST(makeRequest({ matchId: "match-999" }) as any);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when matchId is missing", async () => {
+    const response = await POST(makeRequest({}) as any);
+    expect(response.status).toBe(400);
+  });
+
+  it("records click without auth (unauthenticated SW fallback)", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "match-1",
+      userId: "user-1",
+      clickedAt: null,
+    });
+    updateOneMock.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest({ matchId: "match-1" }, false) as any);
+
+    expect(response.status).toBe(200);
+    expect(updateOneMock).toHaveBeenCalledWith("match-1", {
+      clickedAt: expect.any(String),
+    });
+    // No ownership check for unauthenticated path
+    expect(verifyAuthTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("unauthenticated path does not overwrite existing clickedAt", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "match-1",
+      userId: "user-1",
+      clickedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({ matchId: "match-1" }, false) as any);
+
+    expect(response.status).toBe(200);
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
+  it("unauthenticated path handles missing notification gracefully", async () => {
+    findByIdMock.mockResolvedValue(null);
+
+    const response = await POST(makeRequest({ matchId: "match-999" }, false) as any);
+
+    // SW fallback — silently succeeds when notification not found
+    expect(response.status).toBe(200);
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/notifications/click/route.ts
+++ b/web/app/api/notifications/click/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { verifyAuthToken } from "@/lib/verifyAuthToken";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/notifications/click
+ *
+ * Records the first click on a push notification.
+ * Idempotent: first-write-wins for clickedAt.
+ *
+ * Auth paths:
+ * - Authenticated (Bearer token): verifies the notification belongs to the user
+ *   before writing clickedAt.
+ * - Unauthenticated (SW fallback): records the click for aggregate counts only,
+ *   without userId attribution check. Accepts { matchId } in body.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { matchId } = body;
+
+    if (!matchId || typeof matchId !== "string") {
+      return NextResponse.json(
+        { error: "matchId is required" },
+        { status: 400 },
+      );
+    }
+
+    const db = await getDb();
+
+    const authHeader = request.headers.get("authorization");
+
+    if (authHeader) {
+      // Authenticated path: verify the notification belongs to the user
+      const { userId } = await verifyAuthToken(authHeader);
+
+      const notification = await db.notificationMatches.findById(matchId);
+      if (!notification || notification.userId !== userId) {
+        return NextResponse.json(
+          { error: "Notification not found" },
+          { status: 404 },
+        );
+      }
+
+      // First-write-wins: only set clickedAt if not already set
+      if (!notification.clickedAt) {
+        await db.notificationMatches.updateOne(matchId, {
+          clickedAt: new Date().toISOString(),
+        });
+      }
+    } else {
+      // Unauthenticated SW fallback: record click for aggregate counts
+      // No ownership check — just write if not already set
+      const notification = await db.notificationMatches.findById(matchId);
+      if (notification && !notification.clickedAt) {
+        await db.notificationMatches.updateOne(matchId, {
+          clickedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === "Missing auth token" ||
+        error.message === "Invalid auth token")
+    ) {
+      return NextResponse.json(
+        { error: `Unauthorized - ${error.message}` },
+        { status: 401 },
+      );
+    }
+
+    console.error("Error recording notification click:", error);
+    return NextResponse.json(
+      { error: "Failed to record notification click" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/api/notifications/mark-read/__tests__/route.test.ts
+++ b/web/app/api/notifications/mark-read/__tests__/route.test.ts
@@ -34,6 +34,7 @@ describe("POST /api/notifications/mark-read", () => {
       _id: "notif-1",
       userId: "user-1",
       readAt: null,
+      openedAt: null,
     });
     updateOneMock.mockResolvedValue(undefined);
 
@@ -54,7 +55,37 @@ describe("POST /api/notifications/mark-read", () => {
     expect(findByIdMock).toHaveBeenCalledWith("notif-1");
     expect(updateOneMock).toHaveBeenCalledWith("notif-1", {
       readAt: expect.any(String),
+      openedAt: expect.any(String),
     });
+  });
+
+  it("sets readAt but does not overwrite existing openedAt (first-write-wins)", async () => {
+    findByIdMock.mockResolvedValue({
+      _id: "notif-1",
+      userId: "user-1",
+      readAt: null,
+      openedAt: "2026-01-01T00:00:00.000Z",
+    });
+    updateOneMock.mockResolvedValue(undefined);
+
+    const request = new Request("http://localhost/api/notifications/mark-read", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ notificationId: "notif-1" }),
+    });
+
+    const response = await POST(request as any);
+
+    expect(response.status).toBe(200);
+    expect(updateOneMock).toHaveBeenCalledWith("notif-1", {
+      readAt: expect.any(String),
+      // openedAt NOT included because it was already set
+    });
+    const callArg = updateOneMock.mock.calls[0][1];
+    expect(callArg).not.toHaveProperty("openedAt");
   });
 
   it("returns 400 when notificationId is missing", async () => {

--- a/web/app/api/notifications/mark-read/route.ts
+++ b/web/app/api/notifications/mark-read/route.ts
@@ -29,10 +29,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Mark as read
-    await db.notificationMatches.updateOne(notificationId, {
+    // Mark as read and set openedAt on first open (first-write-wins)
+    const updateData: Record<string, string> = {
       readAt: new Date().toISOString(),
-    });
+    };
+    if (!notification.openedAt) {
+      updateData.openedAt = new Date().toISOString();
+    }
+    await db.notificationMatches.updateOne(notificationId, updateData);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/web/app/api/notifications/report/__tests__/aggregation.test.ts
+++ b/web/app/api/notifications/report/__tests__/aggregation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateNotificationKpis,
+  buildHeatmapResult,
+  extractHeatmapPointsFromMessage,
+  getMessageIdsForMode,
+  HEATMAP_PRIVACY_THRESHOLD,
+} from "../aggregation";
+
+describe("aggregateNotificationKpis", () => {
+  it("returns zero totals for empty input", () => {
+    const result = aggregateNotificationKpis([]);
+    expect(result).toEqual({
+      sent: 0,
+      uniqueUsers: 0,
+      clicked: 0,
+      opened: 0,
+      sources: [],
+    });
+  });
+
+  it("counts sent, unique users, clicked, opened correctly", () => {
+    const matches = [
+      { userId: "u1", messageId: "m1", clickedAt: "2026-01-01", openedAt: undefined, messageSnapshot: { source: "src-a" } },
+      { userId: "u2", messageId: "m2", clickedAt: undefined, openedAt: "2026-01-01", messageSnapshot: { source: "src-a" } },
+      { userId: "u1", messageId: "m3", clickedAt: undefined, openedAt: undefined, messageSnapshot: { source: "src-b" } },
+    ];
+
+    const result = aggregateNotificationKpis(matches);
+
+    expect(result.sent).toBe(3);
+    expect(result.uniqueUsers).toBe(2);
+    expect(result.clicked).toBe(1);
+    expect(result.opened).toBe(1);
+  });
+
+  it("groups sources and sorts by sent count descending", () => {
+    const matches = [
+      { userId: "u1", messageId: "m1", messageSnapshot: { source: "src-b" } },
+      { userId: "u2", messageId: "m2", messageSnapshot: { source: "src-a" } },
+      { userId: "u3", messageId: "m3", messageSnapshot: { source: "src-a" } },
+    ];
+
+    const result = aggregateNotificationKpis(matches);
+
+    expect(result.sources[0].source).toBe("src-a");
+    expect(result.sources[0].sent).toBe(2);
+    expect(result.sources[1].source).toBe("src-b");
+    expect(result.sources[1].sent).toBe(1);
+  });
+
+  it("uses (unknown) source when messageSnapshot is missing", () => {
+    const matches = [{ userId: "u1", messageId: "m1" }];
+    const result = aggregateNotificationKpis(matches);
+    expect(result.sources[0].source).toBe("(unknown)");
+  });
+
+  it("counts clicked per source", () => {
+    const matches = [
+      { userId: "u1", messageId: "m1", clickedAt: "2026-01-01", messageSnapshot: { source: "src-a" } },
+      { userId: "u2", messageId: "m2", clickedAt: undefined, messageSnapshot: { source: "src-a" } },
+    ];
+
+    const result = aggregateNotificationKpis(matches);
+    expect(result.sources[0].clicked).toBe(1);
+  });
+});
+
+describe("getMessageIdsForMode", () => {
+  const matches = [
+    { messageId: "m1", clickedAt: "2026-01-01", openedAt: "2026-01-01" },
+    { messageId: "m2", clickedAt: "2026-01-01", openedAt: undefined },
+    { messageId: "m3", clickedAt: undefined, openedAt: "2026-01-01" },
+    { messageId: "m4", clickedAt: undefined, openedAt: undefined },
+  ];
+
+  it('returns all messageIds for mode "all"', () => {
+    expect(getMessageIdsForMode(matches, "all")).toEqual(["m1", "m2", "m3", "m4"]);
+  });
+
+  it('returns only clicked messageIds for mode "clicked"', () => {
+    expect(getMessageIdsForMode(matches, "clicked")).toEqual(["m1", "m2"]);
+  });
+
+  it('returns only opened messageIds for mode "opened"', () => {
+    expect(getMessageIdsForMode(matches, "opened")).toEqual(["m1", "m3"]);
+  });
+
+  it("filters out null/empty messageIds", () => {
+    const m = [{ messageId: "", clickedAt: "x" }, { messageId: null, clickedAt: "x" }];
+    expect(getMessageIdsForMode(m, "all")).toEqual([]);
+  });
+});
+
+describe("extractHeatmapPointsFromMessage", () => {
+  it("returns empty array for city-wide messages", () => {
+    expect(extractHeatmapPointsFromMessage({ cityWide: true })).toEqual([]);
+  });
+
+  it("returns empty array when geoJson is missing", () => {
+    expect(extractHeatmapPointsFromMessage({})).toEqual([]);
+  });
+
+  it("extracts [lat, lng] from Point geometry", () => {
+    const msg = {
+      geoJson: {
+        features: [
+          { geometry: { type: "Point", coordinates: [23.3, 42.7] } },
+        ],
+      },
+    };
+    expect(extractHeatmapPointsFromMessage(msg)).toEqual([[42.7, 23.3]]);
+  });
+
+  it("extracts points from MultiPoint geometry", () => {
+    const msg = {
+      geoJson: {
+        features: [
+          { geometry: { type: "MultiPoint", coordinates: [[23.3, 42.7], [23.4, 42.8]] } },
+        ],
+      },
+    };
+    expect(extractHeatmapPointsFromMessage(msg)).toEqual([[42.7, 23.3], [42.8, 23.4]]);
+  });
+
+  it("extracts points from LineString geometry", () => {
+    const msg = {
+      geoJson: {
+        features: [
+          { geometry: { type: "LineString", coordinates: [[23.3, 42.7], [23.4, 42.8]] } },
+        ],
+      },
+    };
+    expect(extractHeatmapPointsFromMessage(msg)).toEqual([[42.7, 23.3], [42.8, 23.4]]);
+  });
+
+  it("extracts points from Polygon geometry", () => {
+    const msg = {
+      geoJson: {
+        features: [
+          { geometry: { type: "Polygon", coordinates: [[[23.3, 42.7], [23.4, 42.8], [23.3, 42.7]]] } },
+        ],
+      },
+    };
+    expect(extractHeatmapPointsFromMessage(msg)).toEqual([[42.7, 23.3], [42.8, 23.4], [42.7, 23.3]]);
+  });
+});
+
+describe("buildHeatmapResult", () => {
+  const threshold = HEATMAP_PRIVACY_THRESHOLD;
+  const mockPoints: [number, number][] = [[42.7, 23.3]];
+
+  it(`hides heatmap when count is below ${threshold}`, () => {
+    const result = buildHeatmapResult(threshold - 1, mockPoints);
+    expect(result.heatmapHiddenForPrivacy).toBe(true);
+    expect(result.points).toEqual([]);
+  });
+
+  it(`hides heatmap when count is exactly ${threshold - 1}`, () => {
+    const result = buildHeatmapResult(0, mockPoints);
+    expect(result.heatmapHiddenForPrivacy).toBe(true);
+  });
+
+  it(`shows heatmap when count meets threshold (${threshold})`, () => {
+    const result = buildHeatmapResult(threshold, mockPoints);
+    expect(result.heatmapHiddenForPrivacy).toBe(false);
+    expect(result.points).toEqual(mockPoints);
+  });
+
+  it("shows heatmap when count exceeds threshold", () => {
+    const result = buildHeatmapResult(threshold + 10, mockPoints);
+    expect(result.heatmapHiddenForPrivacy).toBe(false);
+    expect(result.points).toEqual(mockPoints);
+  });
+});

--- a/web/app/api/notifications/report/__tests__/route.test.ts
+++ b/web/app/api/notifications/report/__tests__/route.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { hasReportPagesEnabled } from "@/lib/report-pages";
+
+const { findManyMatchesMock, findManyMessagesMock } = vi.hoisted(() => ({
+  findManyMatchesMock: vi.fn(),
+  findManyMessagesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn().mockResolvedValue({
+    notificationMatches: {
+      findMany: findManyMatchesMock,
+    },
+    messages: {
+      findMany: findManyMessagesMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/report-pages", () => ({
+  hasReportPagesEnabled: vi.fn().mockReturnValue(true),
+}));
+
+function makeRequest(mode?: string) {
+  const url = mode
+    ? `http://localhost/api/notifications/report?mode=${mode}`
+    : "http://localhost/api/notifications/report";
+  return new Request(url);
+}
+
+function makeMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "m1",
+    userId: "u1",
+    messageId: "msg1",
+    notified: true,
+    clickedAt: null,
+    openedAt: null,
+    messageSnapshot: { source: "src-a" },
+    ...overrides,
+  };
+}
+
+function makeMessage(id: string, coords?: [number, number]) {
+  return {
+    _id: id,
+    cityWide: false,
+    geoJson: coords
+      ? {
+          features: [
+            { geometry: { type: "Point", coordinates: [coords[1], coords[0]] } },
+          ],
+        }
+      : { features: [] },
+  };
+}
+
+describe("GET /api/notifications/report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hasReportPagesEnabled).mockReturnValue(true);
+    findManyMatchesMock.mockResolvedValue([]);
+    findManyMessagesMock.mockResolvedValue([]);
+  });
+
+  it("returns 503 when report pages are not enabled", async () => {
+    vi.mocked(hasReportPagesEnabled).mockReturnValue(false);
+
+    const response = await GET(makeRequest() as any);
+    expect(response.status).toBe(503);
+  });
+
+  it("returns empty KPIs for no matches", async () => {
+    const response = await GET(makeRequest() as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sent).toBe(0);
+    expect(data.uniqueUsers).toBe(0);
+    expect(data.clicked).toBe(0);
+    expect(data.opened).toBe(0);
+    expect(data.sources).toEqual([]);
+  });
+
+  it("returns correct KPIs", async () => {
+    findManyMatchesMock.mockResolvedValue([
+      makeMatch({ userId: "u1", clickedAt: "2026-01-01", openedAt: "2026-01-01" }),
+      makeMatch({ userId: "u2", clickedAt: null, openedAt: null, messageId: "msg2" }),
+    ]);
+    findManyMessagesMock.mockResolvedValue([
+      makeMessage("msg1", [42.7, 23.3]),
+      makeMessage("msg2", [42.8, 23.4]),
+    ]);
+
+    const response = await GET(makeRequest() as any);
+    const data = await response.json();
+
+    expect(data.sent).toBe(2);
+    expect(data.uniqueUsers).toBe(2);
+    expect(data.clicked).toBe(1);
+    expect(data.opened).toBe(1);
+  });
+
+  it("hides heatmap for privacy when fewer than 50 records in mode", async () => {
+    // 1 match in "all" mode — below threshold of 50
+    findManyMatchesMock.mockResolvedValue([
+      makeMatch({ messageId: "msg1" }),
+    ]);
+    findManyMessagesMock.mockResolvedValue([makeMessage("msg1", [42.7, 23.3])]);
+
+    const response = await GET(makeRequest("all") as any);
+    const data = await response.json();
+
+    expect(data.heatmapHiddenForPrivacy).toBe(true);
+    expect(data.heatmapPoints).toEqual([]);
+  });
+
+  it("returns heatmap points when >= 50 records in mode", async () => {
+    const matches = Array.from({ length: 50 }, (_, i) => makeMatch({ messageId: `msg${i}` }));
+    findManyMatchesMock.mockResolvedValue(matches);
+    findManyMessagesMock.mockResolvedValue(
+      matches.map((m) => makeMessage(String(m.messageId), [42.7 + Number(String(m.messageId).replace("msg", "")) * 0.001, 23.3])),
+    );
+
+    const response = await GET(makeRequest("all") as any);
+    const data = await response.json();
+
+    expect(data.heatmapHiddenForPrivacy).toBe(false);
+    expect(data.heatmapPoints.length).toBe(50);
+  });
+
+  it('filters heatmap to only clicked matches when mode="clicked"', async () => {
+    findManyMatchesMock.mockResolvedValue([
+      makeMatch({ messageId: "msg1", clickedAt: "2026-01-01" }),
+      makeMatch({ messageId: "msg2", clickedAt: null }),
+    ]);
+    findManyMessagesMock.mockResolvedValue([makeMessage("msg1", [42.7, 23.3])]);
+
+    const response = await GET(makeRequest("clicked") as any);
+    const data = await response.json();
+
+    // Only 1 clicked — below threshold, heatmap hidden
+    expect(data.heatmapHiddenForPrivacy).toBe(true);
+  });
+
+  it('filters heatmap to only opened matches when mode="opened"', async () => {
+    findManyMatchesMock.mockResolvedValue([
+      makeMatch({ messageId: "msg1", openedAt: "2026-01-01" }),
+      makeMatch({ messageId: "msg2", openedAt: null }),
+    ]);
+    findManyMessagesMock.mockResolvedValue([makeMessage("msg1", [42.7, 23.3])]);
+
+    const response = await GET(makeRequest("opened") as any);
+    const data = await response.json();
+
+    // Only 1 opened — below threshold, heatmap hidden
+    expect(data.heatmapHiddenForPrivacy).toBe(true);
+  });
+
+  it("defaults to mode=all for unknown mode values", async () => {
+    findManyMatchesMock.mockResolvedValue([makeMatch()]);
+    findManyMessagesMock.mockResolvedValue([makeMessage("msg1", [42.7, 23.3])]);
+
+    // Should not throw; unknown mode falls back to "all"
+    const response = await GET(makeRequest("invalid") as any);
+    expect(response.status).toBe(200);
+  });
+
+  it("returns source breakdown", async () => {
+    findManyMatchesMock.mockResolvedValue([
+      makeMatch({ messageSnapshot: { source: "src-a" }, clickedAt: "2026-01-01" }),
+      makeMatch({ messageSnapshot: { source: "src-a" }, messageId: "msg2" }),
+      makeMatch({ messageSnapshot: { source: "src-b" }, messageId: "msg3" }),
+    ]);
+    findManyMessagesMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest() as any);
+    const data = await response.json();
+
+    expect(data.sources[0]).toEqual({ source: "src-a", sent: 2, clicked: 1 });
+    expect(data.sources[1]).toEqual({ source: "src-b", sent: 1, clicked: 0 });
+  });
+
+  it("returns 500 on database error", async () => {
+    findManyMatchesMock.mockRejectedValue(new Error("DB error"));
+
+    const response = await GET(makeRequest() as any);
+    expect(response.status).toBe(500);
+  });
+});

--- a/web/app/api/notifications/report/aggregation.ts
+++ b/web/app/api/notifications/report/aggregation.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure aggregation functions for the notifications report API.
+ * No web runtime dependencies — fully unit-testable.
+ */
+
+export type HeatmapMode = "all" | "clicked" | "opened";
+export type HeatmapPoint = [number, number];
+
+/** Minimum record count required to show heatmap points (privacy threshold). */
+export const HEATMAP_PRIVACY_THRESHOLD = 50;
+
+export interface NotificationMatchRecord {
+  _id?: unknown;
+  userId?: unknown;
+  messageId?: unknown;
+  notified?: unknown;
+  clickedAt?: unknown;
+  openedAt?: unknown;
+  messageSnapshot?: unknown;
+}
+
+export interface SourceBreakdown {
+  source: string;
+  sent: number;
+  clicked: number;
+}
+
+export interface ReportAggregation {
+  sent: number;
+  uniqueUsers: number;
+  clicked: number;
+  opened: number;
+  sources: SourceBreakdown[];
+}
+
+export interface HeatmapResult {
+  points: HeatmapPoint[];
+  heatmapHiddenForPrivacy: boolean;
+}
+
+/**
+ * Aggregate KPI metrics from a list of notified notification match records.
+ */
+export function aggregateNotificationKpis(
+  matches: NotificationMatchRecord[],
+): ReportAggregation {
+  const userIds = new Set<string>();
+  let clicked = 0;
+  let opened = 0;
+  const sourceMap = new Map<string, { sent: number; clicked: number }>();
+
+  for (const match of matches) {
+    if (typeof match.userId === "string" && match.userId) {
+      userIds.add(match.userId);
+    }
+
+    if (match.clickedAt) clicked++;
+    if (match.openedAt) opened++;
+
+    const source =
+      typeof match.messageSnapshot === "object" &&
+      match.messageSnapshot !== null &&
+      "source" in match.messageSnapshot &&
+      typeof match.messageSnapshot.source === "string"
+        ? match.messageSnapshot.source
+        : "(unknown)";
+
+    const existing = sourceMap.get(source) ?? { sent: 0, clicked: 0 };
+    existing.sent++;
+    if (match.clickedAt) existing.clicked++;
+    sourceMap.set(source, existing);
+  }
+
+  const sources: SourceBreakdown[] = Array.from(sourceMap.entries())
+    .map(([source, counts]) => ({ source, ...counts }))
+    .sort((a, b) => b.sent - a.sent);
+
+  return {
+    sent: matches.length,
+    uniqueUsers: userIds.size,
+    clicked,
+    opened,
+    sources,
+  };
+}
+
+/**
+ * Filter matches by heatmap mode and extract their messageIds.
+ */
+export function getMessageIdsForMode(
+  matches: NotificationMatchRecord[],
+  mode: HeatmapMode,
+): string[] {
+  return matches
+    .filter((m) => {
+      if (mode === "clicked") return Boolean(m.clickedAt);
+      if (mode === "opened") return Boolean(m.openedAt);
+      return true; // "all"
+    })
+    .map((m) => (typeof m.messageId === "string" ? m.messageId : null))
+    .filter((id): id is string => id !== null && id !== "");
+}
+
+/**
+ * Extract [lat, lng] heatmap points from a message's geoJson field.
+ * Returns [lat, lng] order (Leaflet convention).
+ * Skips city-wide messages.
+ */
+export function extractHeatmapPointsFromMessage(message: {
+  cityWide?: unknown;
+  geoJson?: unknown;
+}): HeatmapPoint[] {
+  if (message.cityWide) return [];
+
+  const rawGeoJson = message.geoJson;
+  if (
+    !rawGeoJson ||
+    typeof rawGeoJson !== "object" ||
+    !("features" in rawGeoJson) ||
+    !Array.isArray(rawGeoJson.features)
+  ) {
+    return [];
+  }
+
+  const points: HeatmapPoint[] = [];
+
+  for (const feature of rawGeoJson.features) {
+    if (!feature || typeof feature !== "object" || !("geometry" in feature)) continue;
+    const geom = feature.geometry;
+    if (!geom || typeof geom !== "object" || !("type" in geom) || !("coordinates" in geom)) continue;
+
+    const geomType = geom.type;
+    const geomCoords = geom.coordinates;
+
+    if (geomType === "Point" && Array.isArray(geomCoords)) {
+      const lng = geomCoords[0];
+      const lat = geomCoords[1];
+      if (typeof lat === "number" && typeof lng === "number") {
+        points.push([lat, lng]);
+      }
+    } else if (
+      (geomType === "MultiPoint" || geomType === "LineString") &&
+      Array.isArray(geomCoords)
+    ) {
+      for (const coord of geomCoords) {
+        if (Array.isArray(coord)) {
+          const lng = coord[0];
+          const lat = coord[1];
+          if (typeof lat === "number" && typeof lng === "number") {
+            points.push([lat, lng]);
+          }
+        }
+      }
+    } else if (geomType === "Polygon" && Array.isArray(geomCoords)) {
+      for (const ring of geomCoords) {
+        if (Array.isArray(ring)) {
+          for (const coord of ring) {
+            if (Array.isArray(coord)) {
+              const lng = coord[0];
+              const lat = coord[1];
+              if (typeof lat === "number" && typeof lng === "number") {
+                points.push([lat, lng]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return points;
+}
+
+/**
+ * Build heatmap result for a set of messageIds, applying the privacy threshold.
+ * Returns empty points and heatmapHiddenForPrivacy=true when count < threshold.
+ */
+export function buildHeatmapResult(
+  matchCount: number,
+  pointsFromMessages: HeatmapPoint[],
+): HeatmapResult {
+  if (matchCount < HEATMAP_PRIVACY_THRESHOLD) {
+    return { points: [], heatmapHiddenForPrivacy: true };
+  }
+  return { points: pointsFromMessages, heatmapHiddenForPrivacy: false };
+}

--- a/web/app/api/notifications/report/route.ts
+++ b/web/app/api/notifications/report/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { hasReportPagesEnabled } from "@/lib/report-pages";
+import {
+  aggregateNotificationKpis,
+  buildHeatmapResult,
+  extractHeatmapPointsFromMessage,
+  getMessageIdsForMode,
+  type HeatmapMode,
+  type HeatmapPoint,
+} from "./aggregation";
+
+export const runtime = "nodejs";
+
+const VALID_MODES: HeatmapMode[] = ["all", "clicked", "opened"];
+
+/**
+ * GET /api/notifications/report?mode=all|clicked|opened
+ *
+ * Returns all-time notification analytics:
+ * - KPIs: sent, unique users, clicked, opened
+ * - Heatmap points from triggering message coordinates, filtered by mode
+ * - Source breakdown: sent + clicked counts per source
+ *
+ * Applies a privacy threshold: if the selected mode has fewer than 50 records,
+ * heatmap points are withheld and heatmapHiddenForPrivacy=true is returned.
+ *
+ * Public route — no auth required. Gated by hasReportPagesEnabled().
+ */
+export async function GET(request: NextRequest) {
+  if (!hasReportPagesEnabled()) {
+    return NextResponse.json(
+      { error: "Report pages not configured" },
+      { status: 503 },
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const rawMode = searchParams.get("mode") ?? "all";
+  const mode: HeatmapMode = VALID_MODES.find((m) => m === rawMode) ?? "all";
+
+  try {
+    const db = await getDb();
+
+    // Fetch all notified notification matches (select only fields needed)
+    const allMatches = await db.notificationMatches.findMany({
+      where: [{ field: "notified", op: "==", value: true }],
+      select: [
+        "_id",
+        "userId",
+        "messageId",
+        "clickedAt",
+        "openedAt",
+        "messageSnapshot",
+      ],
+    });
+
+    const kpis = aggregateNotificationKpis(allMatches);
+
+    // Collect unique messageIds for the selected heatmap mode
+    const messageIds = getMessageIdsForMode(allMatches, mode);
+    const uniqueMessageIds = [...new Set(messageIds)];
+
+    // Fetch matching messages to extract coordinates (only geoJson + cityWide)
+    const heatmapPoints: HeatmapPoint[] = [];
+    if (uniqueMessageIds.length > 0) {
+      const messages = await db.messages.findMany({
+        where: [{ field: "_id", op: "in", value: uniqueMessageIds }],
+        select: ["_id", "geoJson", "cityWide"],
+      });
+
+      // Build a map from messageId → coordinates
+      const messageCoordMap = new Map<string, HeatmapPoint[]>();
+      for (const msg of messages) {
+        const id = typeof msg._id === "string" ? msg._id : "";
+        if (id) {
+          messageCoordMap.set(id, extractHeatmapPointsFromMessage(msg));
+        }
+      }
+
+      // Each notification match contributes the points from its triggering message (1:1)
+      for (const matchMessageId of messageIds) {
+        const pts = messageCoordMap.get(matchMessageId);
+        if (pts) {
+          heatmapPoints.push(...pts);
+        }
+      }
+    }
+
+    const { points, heatmapHiddenForPrivacy } = buildHeatmapResult(
+      messageIds.length,
+      heatmapPoints,
+    );
+
+    return NextResponse.json(
+      {
+        sent: kpis.sent,
+        uniqueUsers: kpis.uniqueUsers,
+        clicked: kpis.clicked,
+        opened: kpis.opened,
+        heatmapPoints: points,
+        heatmapHiddenForPrivacy,
+        sources: kpis.sources,
+      },
+      {
+        headers: {
+          // Cache for 5 minutes — analytics data is not real-time
+          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Error generating notifications report:", error);
+    return NextResponse.json(
+      { error: "Failed to generate notifications report" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -106,7 +106,7 @@ export default function RootLayout({
             </Script>
           </>
         )}
-        <ClientLayout showHistoryReportLink={showHistoryReportLink}>
+        <ClientLayout showHistoryReportLink={showHistoryReportLink} showNotificationsReportLink={showHistoryReportLink}>
           {children}
         </ClientLayout>
       </body>

--- a/web/app/notifications-report/NotificationsReportClient.tsx
+++ b/web/app/notifications-report/NotificationsReportClient.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import type { HeatmapMode } from "../api/notifications/report/aggregation";
+
+const NotificationsReportMapClient = dynamic(
+  () => import("./NotificationsReportMapClient"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-full h-full min-h-[400px] flex items-center justify-center bg-neutral-light">
+        <div className="text-center space-y-2">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
+          <p className="text-sm text-neutral">Зареждане на картата...</p>
+        </div>
+      </div>
+    ),
+  },
+);
+
+interface SourceRow {
+  source: string;
+  sent: number;
+  clicked: number;
+}
+
+interface ReportData {
+  sent: number;
+  uniqueUsers: number;
+  clicked: number;
+  opened: number;
+  heatmapPoints: [number, number][];
+  heatmapHiddenForPrivacy: boolean;
+  sources: SourceRow[];
+}
+
+const MODE_LABELS: Record<HeatmapMode, string> = {
+  all: "Всички",
+  clicked: "Кликнати",
+  opened: "Отворени",
+};
+
+async function fetchReport(mode: HeatmapMode): Promise<ReportData> {
+  const response = await fetch(`/api/notifications/report?mode=${mode}`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch notifications report");
+  }
+  const data: ReportData = await response.json();
+  return data;
+}
+
+export default function NotificationsReportClient() {
+  const [mode, setMode] = useState<HeatmapMode>("all");
+  const [data, setData] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load data when mode changes — triggered by the map component via a stable callback.
+  // We lift the fetch here so KPIs and map share the same data fetch.
+  const [mapMode, setMapMode] = useState<HeatmapMode>("all");
+
+  function handleModeChange(newMode: HeatmapMode) {
+    setMode(newMode);
+    setMapMode(newMode);
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 pb-12 space-y-10">
+      {/* KPI cards */}
+      <ReportKpis
+        mode={mode}
+        onModeChange={handleModeChange}
+        onDataLoaded={(d) => { setData(d); setLoading(false); setError(null); }}
+        onError={(e) => { setError(e); setLoading(false); }}
+        loading={loading}
+      />
+
+      {error && (
+        <p className="text-sm text-error">
+          Грешка при зареждане на данните: {error}
+        </p>
+      )}
+
+      {/* Source breakdown table */}
+      {data && data.sources.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-4">
+            Разбивка по извор
+          </h2>
+          <div className="overflow-x-auto rounded-lg border border-neutral-border">
+            <table className="w-full text-sm">
+              <thead className="bg-neutral-surface">
+                <tr>
+                  <th className="text-left px-4 py-3 font-semibold text-foreground">
+                    Извор
+                  </th>
+                  <th className="text-right px-4 py-3 font-semibold text-foreground">
+                    Изпратени
+                  </th>
+                  <th className="text-right px-4 py-3 font-semibold text-foreground">
+                    Кликнати
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.sources.map((row) => (
+                  <tr
+                    key={row.source}
+                    className="border-t border-neutral-border"
+                  >
+                    <td className="px-4 py-3 text-foreground">{row.source}</td>
+                    <td className="px-4 py-3 text-right text-neutral">
+                      {row.sent.toLocaleString("bg-BG")}
+                    </td>
+                    <td className="px-4 py-3 text-right text-neutral">
+                      {row.clicked.toLocaleString("bg-BG")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Heatmap section */}
+      <section>
+        <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+          <h2 className="text-xl font-semibold text-foreground">
+            Карта на известията
+          </h2>
+          <div className="flex gap-2">
+            {(["all", "clicked", "opened"] satisfies HeatmapMode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => handleModeChange(m)}
+                className={[
+                  "px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+                  mode === m
+                    ? "bg-primary text-white"
+                    : "bg-neutral-surface text-foreground border border-neutral-border hover:bg-neutral-border",
+                ].join(" ")}
+              >
+                {MODE_LABELS[m]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {data?.heatmapHiddenForPrivacy ? (
+          <div className="rounded-lg border border-neutral-border bg-neutral-surface p-6 text-sm text-neutral text-center">
+            Картата е скрита — трябват поне 50 записа в избрания режим, за да
+            бъде показана.
+          </div>
+        ) : (
+          <div className="rounded-lg overflow-hidden border border-neutral-border h-[450px]">
+            <NotificationsReportMapClient
+              mode={mapMode}
+              points={data?.heatmapPoints ?? []}
+              loading={loading}
+            />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Loads report data and renders KPI cards.
+ * Separated so it can trigger the initial fetch and notify the parent.
+ */
+function ReportKpis({
+  mode,
+  onModeChange,
+  onDataLoaded,
+  onError,
+  loading,
+}: {
+  mode: HeatmapMode;
+  onModeChange: (mode: HeatmapMode) => void;
+  onDataLoaded: (data: ReportData) => void;
+  onError: (error: string) => void;
+  loading: boolean;
+}) {
+  const [data, setData] = useState<ReportData | null>(null);
+  const [fetching, setFetching] = useState(false);
+  const [lastMode, setLastMode] = useState<HeatmapMode | null>(null);
+
+  if (mode !== lastMode && !fetching) {
+    setFetching(true);
+    setLastMode(mode);
+    fetchReport(mode)
+      .then((d) => {
+        setData(d);
+        onDataLoaded(d);
+      })
+      .catch((e: unknown) => {
+        onError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => setFetching(false));
+  }
+
+  const kpis = data
+    ? [
+        { label: "Изпратени", value: data.sent },
+        { label: "Уникални потребители", value: data.uniqueUsers },
+        { label: "Кликнати", value: data.clicked },
+        { label: "Отворени", value: data.opened },
+      ]
+    : null;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      {kpis
+        ? kpis.map(({ label, value }) => (
+            <div
+              key={label}
+              className="bg-neutral-surface rounded-lg border border-neutral-border p-4 text-center"
+            >
+              <div className="text-2xl font-bold text-primary">
+                {value.toLocaleString("bg-BG")}
+              </div>
+              <div className="text-xs text-neutral mt-1">{label}</div>
+            </div>
+          ))
+        : Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-neutral-surface rounded-lg border border-neutral-border p-4 h-20 animate-pulse"
+            />
+          ))}
+    </div>
+  );
+}

--- a/web/app/notifications-report/NotificationsReportMapClient.tsx
+++ b/web/app/notifications-report/NotificationsReportMapClient.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { colors } from "@/lib/colors";
+import { getLocalityCenter } from "@/lib/bounds-utils";
+import type { HeatmapMode } from "../api/notifications/report/aggregation";
+
+type HeatmapPoint = [number, number];
+
+declare module "leaflet" {
+  export function heatLayer(
+    points: HeatmapPoint[],
+    options: Record<string, unknown>,
+  ): import("leaflet").Layer;
+}
+
+interface NotificationsReportMapClientProps {
+  readonly mode: HeatmapMode;
+  readonly points: HeatmapPoint[];
+  readonly loading: boolean;
+}
+
+const DEFAULT_ZOOM = 13;
+const MAP_CENTER = getLocalityCenter();
+
+const HEATMAP_GRADIENT = {
+  0.4: colors.zones.blue,
+  0.65: colors.semantic.warning,
+  1: colors.semantic.error,
+};
+
+export default function NotificationsReportMapClient({
+  mode,
+  points,
+  loading,
+}: NotificationsReportMapClientProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<import("leaflet").Map | null>(null);
+  const heatLayerRef = useRef<import("leaflet").Layer | null>(null);
+  const leafletRef = useRef<typeof import("leaflet") | null>(null);
+  const isMapReadyRef = useRef(false);
+
+  // Initialise map once on mount
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+    let cancelled = false;
+
+    async function initMap() {
+      try {
+        const leafletModule = await import("leaflet");
+        const L: typeof import("leaflet") =
+          "default" in leafletModule ? leafletModule.default : leafletModule;
+        await import("leaflet.heat");
+
+        if (cancelled || !mapRef.current) return;
+
+        await import("leaflet/dist/leaflet.css");
+
+        const map = L.map(mapRef.current, {
+          center: MAP_CENTER,
+          zoom: DEFAULT_ZOOM,
+          zoomControl: true,
+        });
+
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+          maxZoom: 19,
+        }).addTo(map);
+
+        mapInstanceRef.current = map;
+        leafletRef.current = L;
+        isMapReadyRef.current = true;
+      } catch {
+        // Map init failed — no-op
+      }
+    }
+
+    initMap();
+
+    return () => {
+      cancelled = true;
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.remove();
+        mapInstanceRef.current = null;
+        isMapReadyRef.current = false;
+      }
+    };
+  }, []);
+
+  // Update heatmap layer when points change
+  useEffect(() => {
+    if (!isMapReadyRef.current || !leafletRef.current || !mapInstanceRef.current) return;
+
+    const L = leafletRef.current;
+    const map = mapInstanceRef.current;
+
+    if (heatLayerRef.current) {
+      map.removeLayer(heatLayerRef.current);
+      heatLayerRef.current = null;
+    }
+
+    if (points.length > 0) {
+      const layer = L.heatLayer(points, {
+        radius: 25,
+        blur: 15,
+        maxZoom: 17,
+        gradient: HEATMAP_GRADIENT,
+      });
+      layer.addTo(map);
+      heatLayerRef.current = layer;
+    }
+  }, [points]);
+
+  return (
+    <div className="relative w-full h-full">
+      {loading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-neutral-light/75">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+      <div ref={mapRef} className="w-full h-full" />
+      {!loading && points.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <p className="text-sm text-neutral bg-neutral-surface/90 px-3 py-2 rounded">
+            Няма данни за показване
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/notifications-report/page.tsx
+++ b/web/app/notifications-report/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import NotificationsReportClient from "./NotificationsReportClient";
+import ReportPageUnavailable from "@/components/ReportPageUnavailable";
+import { hasReportPagesEnabled } from "@/lib/report-pages";
+import { APP_NAME } from "@/lib/pwa-metadata";
+
+export const metadata: Metadata = {
+  title: `Известия | ${APP_NAME}`,
+  description: "Справка за доставените известия — брой изпратени, отворени и кликнати.",
+};
+
+export default function NotificationsReportPage() {
+  if (!hasReportPagesEnabled()) {
+    return (
+      <ReportPageUnavailable
+        title="Известия"
+        message="Тази страница е скрита, защото GCS_GENERIC_BUCKET не е конфигуриран за този fork."
+        backHref="/sources"
+        backLabel="Източници"
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-light flex flex-col">
+      <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href="/"
+            className="text-primary hover:text-primary-hover inline-flex items-center gap-2"
+          >
+            <span>←</span>
+            <span>Начало</span>
+          </Link>
+        </div>
+        <h1 className="text-3xl font-bold text-foreground mb-4">Известия</h1>
+        <p className="text-sm text-neutral">
+          Обобщена справка за всички изпратени известия. Показва колко
+          потребители са получили известие, колко са го кликнали и колко са го
+          отворили, заедно с разбивка по извор на данни.
+        </p>
+      </div>
+
+      <NotificationsReportClient />
+    </div>
+  );
+}

--- a/web/components/ClientLayout.tsx
+++ b/web/components/ClientLayout.tsx
@@ -12,9 +12,11 @@ import { Toaster, toast } from "sonner";
 export default function ClientLayout({
   children,
   showHistoryReportLink,
+  showNotificationsReportLink = false,
 }: Readonly<{
   children: React.ReactNode;
   showHistoryReportLink: boolean;
+  showNotificationsReportLink?: boolean;
 }>) {
   const pathname = usePathname();
   const isClient = typeof window !== "undefined";
@@ -90,6 +92,7 @@ export default function ClientLayout({
               <main className="flex-1 flex flex-col">{children}</main>
               <Footer
                 showHistoryReportLink={showHistoryReportLink}
+                showNotificationsReportLink={showNotificationsReportLink}
                 className={footerClassName || undefined}
               />
             </div>

--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -6,6 +6,7 @@ import { APP_NAME } from "@/lib/pwa-metadata";
 interface FooterProps {
   readonly className?: string;
   readonly showHistoryReportLink: boolean;
+  readonly showNotificationsReportLink?: boolean;
 }
 
 const ABOUT_OBOAPP_LINKS = [
@@ -24,11 +25,15 @@ const DATA_AND_REPORTS_LINKS = [
 export default function Footer({
   className = "",
   showHistoryReportLink,
+  showNotificationsReportLink = false,
 }: FooterProps) {
   const dataAndReportsLinks = showHistoryReportLink
     ? [
         ...DATA_AND_REPORTS_LINKS.slice(0, 2),
         { href: "/history", label: "Исторически данни" },
+        ...(showNotificationsReportLink
+          ? [{ href: "/notifications-report", label: "Известия" }]
+          : []),
         ...DATA_AND_REPORTS_LINKS.slice(2),
       ]
     : DATA_AND_REPORTS_LINKS;

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -114,6 +114,8 @@ export interface NotificationMatch {
   deviceNotifications?: DeviceNotification[]; // Array of device-specific sends
   messageSnapshot?: MessageSnapshot; // Denormalized message data
   readAt?: Date | string; // When the notification was read by the user
+  clickedAt?: Date | string; // First push-notification click event timestamp
+  openedAt?: Date | string; // First explicit open/read action by the user
 }
 
 // Notification History Item (for API response)

--- a/web/public/firebase-messaging-sw.js
+++ b/web/public/firebase-messaging-sw.js
@@ -53,6 +53,7 @@ self.addEventListener("notificationclick", (event) => {
   event.notification.close();
 
   const urlToOpen = event.notification.data?.url || "/";
+  const matchId = event.notification.data?.matchId;
 
   event.waitUntil(
     clients
@@ -69,9 +70,24 @@ self.addEventListener("notificationclick", (event) => {
             client.postMessage({
               type: "NOTIFICATION_CLICKED",
               messageId: event.notification.data?.messageId,
+              matchId,
             });
             return client.focus();
           }
+        }
+
+        // No app window open — fire-and-forget click tracking as unauthenticated fallback
+        if (matchId) {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 3000);
+          fetch("/api/notifications/click", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ matchId }),
+            signal: controller.signal,
+          })
+            .catch(() => {/* best-effort */})
+            .finally(() => clearTimeout(timeoutId));
         }
 
         if (clients.openWindow) {

--- a/web/scripts/firebase-messaging-sw.template.js
+++ b/web/scripts/firebase-messaging-sw.template.js
@@ -53,6 +53,7 @@ self.addEventListener("notificationclick", (event) => {
   event.notification.close();
 
   const urlToOpen = event.notification.data?.url || "/";
+  const matchId = event.notification.data?.matchId;
 
   event.waitUntil(
     clients
@@ -69,9 +70,24 @@ self.addEventListener("notificationclick", (event) => {
             client.postMessage({
               type: "NOTIFICATION_CLICKED",
               messageId: event.notification.data?.messageId,
+              matchId,
             });
             return client.focus();
           }
+        }
+
+        // No app window open — fire-and-forget click tracking as unauthenticated fallback
+        if (matchId) {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 3000);
+          fetch("/api/notifications/click", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ matchId }),
+            signal: controller.signal,
+          })
+            .catch(() => {/* best-effort */})
+            .finally(() => clearTimeout(timeoutId));
         }
 
         if (clients.openWindow) {


### PR DESCRIPTION
Phase 1 — Data model & indexes:
- Add clickedAt and openedAt fields to NotificationMatch type (ingest + web)
- Add MongoDB compound indexes: (userId, clickedAt) and (userId, openedAt)
- Add Firestore composite indexes for analytics query patterns

Phase 2 — Click and open tracking:
- SW template: forward matchId in NOTIFICATION_CLICKED postMessage
- SW template: add fire-and-forget unauthenticated click fallback when no app window is open (3s AbortController timeout)
- Regenerate web/public/firebase-messaging-sw.js from updated template
- Add POST /api/notifications/click: authenticated + unauthenticated paths, first-write-wins idempotency for clickedAt
- Update mark-read route to also set openedAt on first open (first-write-wins) while keeping existing readAt behaviour for unread badge UX

Phase 3 — Analytics API:
- Add pure aggregation module (aggregation.ts) with: aggregateNotificationKpis, getMessageIdsForMode, extractHeatmapPointsFromMessage, buildHeatmapResult
- Add GET /api/notifications/report?mode=all|clicked|opened: KPIs, heatmap points from triggering message coordinates, per-source breakdown; privacy threshold of 50 records; gated by hasReportPagesEnabled(); node runtime with caching headers

Phase 4 — Report page:
- Footer: add Известия link when report pages are enabled
- ClientLayout / layout.tsx: thread showNotificationsReportLink prop
- New page /notifications-report with gating, Bulgarian UI copy
- NotificationsReportClient: KPI cards, mode filter, source table, heatmap section with privacy-threshold message
- NotificationsReportMapClient: Leaflet heatmap renderer reusing HistoryMapClient architecture

Phase 5 — Tests (44 new test cases):
- aggregation.test.ts: 19 unit tests for all pure functions
- click/route.test.ts: 8 tests covering auth + unauth paths, idempotency
- report/route.test.ts: 10 tests covering KPIs, filter modes, privacy threshold, source breakdown, 503 gating, error handling
- mark-read/route.test.ts: extended with 2 tests for openedAt behaviour